### PR TITLE
Add dark theme styling for mission listing

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,0 +1,127 @@
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background-color: #121212;
+  color: #f5f5f5;
+  font-family: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: #80d8ff;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  color: #40c4ff;
+  text-decoration: underline;
+}
+
+.page-container {
+  width: min(100%, 1100px);
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2.5rem;
+  letter-spacing: -0.02em;
+  color: #ffffff;
+}
+
+.page-header p {
+  margin: 0;
+  color: #bdbdbd;
+}
+
+.mission-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+}
+
+.mission-card {
+  background-color: #1e1e1e;
+  border-radius: 18px;
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mission-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.45);
+  border-color: rgba(129, 212, 250, 0.35);
+}
+
+.mission-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #ffffff;
+}
+
+.mission-card p {
+  margin: 0;
+  color: #d0d0d0;
+}
+
+.mission-status {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #90caf9;
+}
+
+.mission-status span {
+  font-weight: 600;
+  color: #81c784;
+}
+
+.mission-meta {
+  font-size: 0.85rem;
+  color: #9e9e9e;
+}
+
+.mission-card.empty-state {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #b0bec5;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+}
+
+@media (max-width: 600px) {
+  .page-container {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .page-header h1 {
+    font-size: 2rem;
+  }
+
+  .mission-card {
+    padding: 1.5rem;
+  }
+}

--- a/templates/missions.html
+++ b/templates/missions.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Misiones</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+  </head>
+  <body>
+    <main class="page-container">
+      <header class="page-header">
+        <h1>Misiones</h1>
+        <p>Explora los objetivos y aventuras disponibles para la tripulación.</p>
+      </header>
+      <section aria-label="Listado de misiones">
+        <div class="mission-grid">
+          {% for mission in missions %}
+          <div class="mission-card">
+            <h2>{{ mission.title or mission.name }}</h2>
+            {% if mission.description or mission.summary %}
+            <p>{{ mission.description or mission.summary }}</p>
+            {% endif %}
+            {% if mission.status %}
+            <p class="mission-status">Estado: <span>{{ mission.status }}</span></p>
+            {% endif %}
+            {% if mission.due_date or mission.deadline %}
+            <p class="mission-meta">Fecha límite: {{ mission.due_date or mission.deadline }}</p>
+            {% endif %}
+            {% if mission.location %}
+            <p class="mission-meta">Ubicación: {{ mission.location }}</p>
+            {% endif %}
+            {% if mission.link %}
+            <a class="mission-meta" href="{{ mission.link }}">Más información</a>
+            {% endif %}
+          </div>
+          {% else %}
+          <div class="mission-card empty-state">
+            <p>No hay misiones disponibles por ahora.</p>
+          </div>
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dark theme palette along with mission grid and card utility styles in `static/css/main.css`
- update the missions template to load the stylesheet and wrap each mission entry with the new structural classes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c88afc5b2c83318817a468e84b6d9f