### PR TITLE
Refactor dark theme styles with shared variables

### DIFF
--- a/frontend/assets/css/style-dark.css
+++ b/frontend/assets/css/style-dark.css
@@ -1,20 +1,312 @@
-/* Dark theme styles for Portal de Misiones */
-body { font-family: Arial, sans-serif; margin: 0; padding: 0; background-color: #0c134f; color: #e5e5f1; }
-header { background-color: #0c134f; color: #e5e5f1; padding: 1rem; display: flex; justify-content: space-between; align-items: center; }
-nav { display: flex; gap: 1.5rem; }
-nav a { color: #a08dff; text-decoration: none; }
-nav a:hover { text-decoration: underline; }
-main { padding: 1rem; max-width: 1000px; margin: 0 auto; }
-section.enroll, section.dashboard, section.mission { background-color: #1d2951; padding: 1.5rem; border-radius: 12px; box-shadow: 0 2px 4px rgba(0,0,0,0.3); margin-bottom: 1.5rem; }
-section h2, section h3 { color: #e5e5f1; margin-top: 0; }
-section p, section li { color: #c5c7e2; }
-form input, form textarea { width: 100%; padding: 0.5rem; border: 1px solid #444; border-radius: 4px; margin-top: 0.3rem; box-sizing: border-box; background-color: #2b365d; color: #e5e5f1; }
-form button { background-color: #2980b9; color: #fff; border: none; border-radius: 4px; padding: 0.75rem 1.25rem; cursor: pointer; transition: background-color 0.2s ease; }
-form button:hover { background-color: #21618c; }
-.missions { list-style: none; padding: 0; margin: 0; }
-.missions li { padding: 0.5rem; border-bottom: 1px solid #444; display: flex; justify-content: space-between; align-items: center; }
-.missions li:last-child { border-bottom: none; }
-.blocked { opacity: 0.5; }
-.feedback { margin-top: 1rem; padding: 1rem; border-radius: 8px; }
-.feedback.success { background-color: #1e4620; color: #d4ffd6; }
-.feedback.error { background-color: #662222; color: #ffd4d4; }
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap");
+
+:root {
+  --bg: #050b18;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --card-bg: #0f172a;
+  --card-border: rgba(148, 163, 184, 0.2);
+  --card-shadow: 0 20px 45px -25px rgba(8, 47, 73, 0.65);
+  --card-shadow-hover: 0 28px 60px -22px rgba(30, 64, 175, 0.55);
+  --accent: #60a5fa;
+  --accent-hover: #3b82f6;
+  --accent-contrast: #f8fafc;
+  --accent-shadow: 0 15px 35px -18px rgba(96, 165, 250, 0.45);
+  --success: #34d399;
+  --warning: #fbbf24;
+  --danger: #f87171;
+  --danger-hover: #ef4444;
+  --danger-shadow: 0 12px 30px -18px rgba(248, 113, 113, 0.55);
+  --locked-bg: rgba(15, 23, 42, 0.65);
+  --locked-border: rgba(148, 163, 184, 0.25);
+  --unlocked-bg: rgba(59, 130, 246, 0.2);
+  --unlocked-border: rgba(59, 130, 246, 0.45);
+  --completed-bg: rgba(34, 197, 94, 0.2);
+  --completed-border: rgba(34, 197, 94, 0.45);
+  --error-bg: rgba(248, 113, 113, 0.18);
+  --error-border: rgba(248, 113, 113, 0.45);
+  --input-bg: rgba(15, 23, 42, 0.85);
+  --input-border: rgba(148, 163, 184, 0.22);
+  --focus-ring: rgba(96, 165, 250, 0.35);
+  --header-gradient-start: #1e3a8a;
+  --header-gradient-end: #0b1120;
+  --radius: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+header {
+  background: linear-gradient(135deg, var(--header-gradient-start), var(--header-gradient-end));
+  color: var(--text);
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  box-shadow: 0 18px 35px -24px rgba(2, 6, 23, 0.9);
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 700;
+}
+
+header nav {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+header nav a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+header nav a:hover {
+  color: var(--accent-hover);
+}
+
+main {
+  padding: clamp(1.5rem, 3vw, 3rem) 1.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+section.enroll,
+section.dashboard,
+section.mission {
+  background-color: var(--card-bg);
+  padding: clamp(1.75rem, 2.5vw, 2.5rem);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  border: 1px solid var(--card-border);
+}
+
+section.enroll h2,
+section.dashboard h2,
+section.mission h2,
+section.mission h3 {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  font-size: clamp(1.5rem, 2vw, 1.75rem);
+  font-weight: 700;
+  color: var(--text);
+}
+
+section.enroll p,
+section.dashboard p,
+section.mission p,
+section.mission li {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: var(--muted);
+}
+
+form label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+form input,
+form select,
+form textarea,
+form button {
+  padding: 0.75rem 0.9rem;
+  margin-top: 0.45rem;
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--input-border);
+  background-color: var(--input-bg);
+  color: var(--text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+form input:focus,
+form select:focus,
+form textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--focus-ring);
+  background-color: var(--card-bg);
+}
+
+form button {
+  background-color: var(--accent);
+  color: var(--accent-contrast);
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: var(--accent-shadow);
+}
+
+form button:hover {
+  background-color: var(--accent-hover);
+}
+
+.missions-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.25rem;
+}
+
+.missions-grid > li {
+  list-style: none;
+  margin: 0;
+}
+
+.mission-card {
+  padding: 1.75rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--card-border);
+  background-color: var(--card-bg);
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  position: relative;
+  color: var(--text);
+}
+
+.mission-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--card-shadow-hover);
+}
+
+.mission-card a {
+  text-decoration: none;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.mission-card a:hover {
+  color: var(--accent-hover);
+}
+
+.mission-card .status {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.mission-card.locked {
+  background-color: var(--locked-bg);
+  border-color: var(--locked-border);
+  color: var(--muted);
+  box-shadow: none;
+}
+
+.mission-card.locked a {
+  color: var(--muted);
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+.mission-card.locked .status {
+  color: var(--muted);
+}
+
+.mission-card.unlocked {
+  background-color: var(--unlocked-bg);
+  border-color: var(--unlocked-border);
+}
+
+.mission-card.unlocked .status {
+  color: var(--warning);
+}
+
+.mission-card.completed {
+  background-color: var(--completed-bg);
+  border-color: var(--completed-border);
+}
+
+.mission-card.completed .status {
+  color: var(--success);
+}
+
+.success {
+  color: var(--success);
+  font-weight: 600;
+}
+
+.fail {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.feedback {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--card-border);
+  background-color: var(--card-bg);
+  color: var(--text);
+}
+
+.feedback.success {
+  background-color: var(--completed-bg);
+  border-color: var(--completed-border);
+  color: var(--success);
+}
+
+.feedback.error {
+  background-color: var(--error-bg);
+  border-color: var(--error-border);
+  color: var(--danger);
+}
+
+button#logoutBtn {
+  margin-top: 1.5rem;
+  background-color: var(--danger);
+  color: var(--accent-contrast);
+  border: none;
+  border-radius: 12px;
+  padding: 0.9rem 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: var(--danger-shadow);
+}
+
+button#logoutBtn:hover {
+  background-color: var(--danger-hover);
+}
+
+@media (max-width: 640px) {
+  header {
+    padding: 2rem 1rem;
+  }
+
+  main {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .missions-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- define dark color variables and shared tokens for the dark theme stylesheet
- update header, navigation, forms, and feedback components to consume the new variables
- copy the missions grid and mission card rules from the light theme for consistent styling

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8af8ce67c8331b0ef430a75d1b017