### PR TITLE
Refactor dark theme to use shared variables

### DIFF
--- a/frontend/assets/css/style-dark.css
+++ b/frontend/assets/css/style-dark.css
@@ -30,6 +30,7 @@
   --focus-ring: rgba(96, 165, 250, 0.35);
   --header-gradient-start: #1e3a8a;
   --header-gradient-end: #0b1120;
+  --header-shadow: 0 18px 35px -24px rgba(2, 6, 23, 0.9);
   --radius: 18px;
 }
 
@@ -56,7 +57,7 @@ header {
   flex-direction: column;
   gap: 1rem;
   align-items: center;
-  box-shadow: 0 18px 35px -24px rgba(2, 6, 23, 0.9);
+  box-shadow: var(--header-shadow);
 }
 
 header h1 {


### PR DESCRIPTION
## Summary
- add a CSS custom property for the dark theme header shadow to keep the palette centralized
- update the header rule to consume the new variable instead of a hard-coded rgba value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b0d37ac8833182325cb1a23f9594