### PR TITLE
Revamp portal header navigation layout

### DIFF
--- a/frontend/assets/css/style-dark.css
+++ b/frontend/assets/css/style-dark.css
@@ -48,39 +48,215 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-header {
+.portal-header {
   background: linear-gradient(135deg, var(--header-gradient-start), var(--header-gradient-end));
   color: var(--text);
-  padding: 2.5rem 1.5rem;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  align-items: center;
+  padding: 2.25rem 1.5rem 2.75rem;
   box-shadow: var(--header-shadow);
 }
 
-header h1 {
+.portal-header__top {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.portal-header__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.portal-header__logo {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 14px;
+  background-color: var(--accent);
+  color: var(--accent-contrast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  box-shadow: var(--accent-shadow);
+}
+
+.portal-header__brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.portal-header__brand-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--accent-contrast);
+}
+
+.portal-header__brand-subtitle {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.portal-header__nav {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-width: 200px;
+}
+
+.portal-header__link {
+  color: var(--accent-contrast);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.portal-header__link:hover,
+.portal-header__link:focus-visible {
+  background-color: rgba(96, 165, 250, 0.15);
+  border-color: rgba(96, 165, 250, 0.35);
+  color: var(--accent-contrast);
+  outline: none;
+}
+
+.portal-header__link--active {
+  background-color: rgba(96, 165, 250, 0.22);
+  border-color: rgba(96, 165, 250, 0.55);
+  box-shadow: var(--accent-shadow);
+}
+
+.portal-header__user {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-left: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.portal-header__user-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.15rem;
+}
+
+.portal-header__user-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.portal-header__user-name {
+  font-weight: 600;
+  color: var(--accent-contrast);
+}
+
+.portal-header__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.portal-header__action {
+  background-color: var(--accent);
+  color: var(--accent-contrast);
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--accent-shadow);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.portal-header__action:hover,
+.portal-header__action:focus-visible {
+  background-color: var(--accent-hover);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.portal-header__action--ghost {
+  background-color: transparent;
+  color: var(--accent);
+  border-color: rgba(96, 165, 250, 0.55);
+  box-shadow: none;
+}
+
+.portal-header__action--ghost:hover,
+.portal-header__action--ghost:focus-visible {
+  background-color: rgba(96, 165, 250, 0.18);
+  color: var(--accent-contrast);
+}
+
+.portal-header__body {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.portal-header__heading {
   margin: 0;
   font-size: clamp(2rem, 4vw, 2.8rem);
   font-weight: 700;
+  color: var(--accent-contrast);
 }
 
-header nav {
-  display: flex;
-  gap: 1.5rem;
-  flex-wrap: wrap;
-  justify-content: center;
+@media (max-width: 768px) {
+  .portal-header__top {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
+  }
+
+  .portal-header__nav {
+    justify-content: flex-start;
+  }
+
+  .portal-header__user {
+    margin-left: 0;
+    align-items: stretch;
+  }
+
+  .portal-header__user-info {
+    align-items: flex-start;
+  }
+
+  .portal-header__actions {
+    justify-content: flex-start;
+  }
 }
 
-header nav a {
-  color: var(--accent);
-  text-decoration: none;
-  font-weight: 600;
-}
+@media (max-width: 520px) {
+  .portal-header__nav {
+    width: 100%;
+  }
 
-header nav a:hover {
-  color: var(--accent-hover);
+  .portal-header__actions {
+    width: 100%;
+  }
+
+  .portal-header__action {
+    flex: 1 1 140px;
+  }
 }
 
 main {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,12 +9,37 @@
   <link rel="stylesheet" href="assets/css/style-dark.css" />
 </head>
 <body>
-  <header>
-    <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-  <h1>Portal de Misiones BlockCorp</h1>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link portal-header__link--active" href="index.html" aria-current="page">Inicio</a>
+        <a class="portal-header__link" href="m1.html">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">Portal de Misiones BlockCorp</h1>
+    </div>
   </header>
   <main id="content">
     <!-- El contenido se inyectará por JavaScript -->

--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -9,12 +9,37 @@
  
 </head>
 <body>
-  <header>
-      <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-    <h1>M1 — La Puerta de la Base (VS Code + Python)</h1>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link" href="index.html">Inicio</a>
+        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">M1 — La Puerta de la Base (VS Code + Python)</h1>
+    </div>
   </header>
   <main>
     <section class="mission">

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -9,12 +9,37 @@
   <link rel="stylesheet" href="assets/css/style-dark.css" />
 </head>
 <body>
-  <header>
-      <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-    <h1>M2 — Despierta a tu Aliado (venv)</h1>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link" href="index.html">Inicio</a>
+        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">M2 — Despierta a tu Aliado (venv)</h1>
+    </div>
   </header>
   <main>
     <section class="mission">

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -9,12 +9,37 @@
   <link rel="stylesheet" href="assets/css/style-dark.css" />
 </head>
 <body>
-  <header>
-      <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-    <h1>M3 — Cofres CSV y DataFrames (pandas)</h1>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link" href="index.html">Inicio</a>
+        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">M3 — Cofres CSV y DataFrames (pandas)</h1>
+    </div>
   </header>
   <main>
     <section class="mission">

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -9,12 +9,37 @@
   <link rel="stylesheet" href="assets/css/style-dark.css" />
 </head>
 <body>
-  <header>
-      <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-    <h1>M4 — Bronze: Ingesta y Copia fiel</h1>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link" href="index.html">Inicio</a>
+        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">M4 — Bronze: Ingesta y Copia fiel</h1>
+    </div>
   </header>
   <main>
     <section class="mission">

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -9,12 +9,37 @@
   <link rel="stylesheet" href="assets/css/style-dark.css" />
 </head>
 <body>
-  <header>
-      <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-    <h1>M5 — Silver: Limpieza y Tipos</h1>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link" href="index.html">Inicio</a>
+        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">M5 — Silver: Limpieza y Tipos</h1>
+    </div>
   </header>
   <main>
     <section class="mission">

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -9,13 +9,38 @@
   <link rel="stylesheet" href="assets/css/style-dark.css">
 </head>
 <body>
-<header>
-  <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-  <h1>M6 — Gold Operaciones: Une y mide</h1>
-</header>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link" href="index.html">Inicio</a>
+        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">M6 — Gold Operaciones: Une y mide</h1>
+    </div>
+  </header>
   <main>
     <section class="mission">
       <h2>Historia</h2>

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -9,13 +9,38 @@
   <link rel="stylesheet" href="assets/css/style-dark.css">
 </head>
 <body>
-<header>
-  <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-  <h1>M6 — Gold (VENTAS): Une y mide</h1>
-</header>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link" href="index.html">Inicio</a>
+        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">M6 — Gold (VENTAS): Une y mide</h1>
+    </div>
+  </header>
   <main>
     <section class="mission">
       <h2>Historia</h2>

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -9,13 +9,38 @@
   <link rel="stylesheet" href="assets/css/style-dark.css">
 </head>
 <body>
-<header>
-  <nav>
-    <a href="index.html">Inicio</a>
-    <a href="m1.html">Inscribirme</a>
-  </nav>
-  <h1>M7 — Consejo de la Tienda (Power BI)</h1>
-</header>
+  <header class="portal-header">
+    <div class="portal-header__top">
+      <div class="portal-header__brand">
+        <span class="portal-header__logo" aria-hidden="true">BC</span>
+        <div class="portal-header__brand-text">
+          <span class="portal-header__brand-title">Portal de Misiones</span>
+          <span class="portal-header__brand-subtitle">BlockCorp</span>
+        </div>
+      </div>
+      <nav class="portal-header__nav" aria-label="Navegación principal">
+        <a class="portal-header__link" href="index.html">Inicio</a>
+        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+      </nav>
+      <div class="portal-header__user">
+        <div class="portal-header__user-info">
+          <span class="portal-header__user-label">Sesión activa</span>
+          <span class="portal-header__user-name">agente.nova</span>
+        </div>
+        <div class="portal-header__actions">
+          <button class="portal-header__action portal-header__action--ghost" type="button">
+            Centro de ayuda
+          </button>
+          <button class="portal-header__action" type="button">
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="portal-header__body">
+      <h1 class="portal-header__heading">M7 — Consejo de la Tienda (Power BI)</h1>
+    </div>
+  </header>
   <main>
     <section class="mission">
       <h2>Historia</h2>


### PR DESCRIPTION
## Summary
- restructure the portal header markup on all pages to include branded navigation, user session info, and action buttons
- style the new header layout with flexbox and accent color tokens in the dark theme stylesheet to match the card aesthetics

## Testing
- not run (static frontend changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8b1d4511c83318ab46ed6c36a2106