### PR TITLE
Fix Inscribirme link to show registration form

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -207,7 +207,11 @@ async function verifyMission(missionId, resultContainer) {
 window.addEventListener('load', () => {
   const slug = localStorage.getItem('student_slug');
   if (window.location.pathname.endsWith('index.html') || window.location.pathname === '/') {
-    if (!slug) {
+    const forceEnroll = window.location.search.includes('enroll');
+    if (forceEnroll) {
+      localStorage.removeItem('student_slug');
+      renderEnrollForm();
+    } else if (!slug) {
       renderEnrollForm();
     } else {
       loadDashboard();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link portal-header__link--active" href="index.html" aria-current="page">Inicio</a>
-        <a class="portal-header__link" href="m1.html">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -20,7 +20,7 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link portal-header__link--active" href="m1.html" aria-current="page">Inscribirme</a>
+        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">


### PR DESCRIPTION
## Summary
- Link "Inscribirme" to `index.html?enroll` across pages
- Load registration form when `?enroll` query is present, clearing previous session

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8b65e34e88331a1752f75b96d46cb