### PR TITLE
Enable enroll form routing from mission pages

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -7,10 +7,30 @@ function $(selector) {
 }
 
 /**
+ * Obtiene o crea el contenedor donde se dibuja el contenido principal.
+ * Permite usar el flujo de matrícula en cualquier archivo HTML.
+ */
+function getContentContainer() {
+  let content = $('#content');
+  if (content) {
+    return content;
+  }
+  const main = document.querySelector('main');
+  if (main) {
+    main.id = 'content';
+    return main;
+  }
+  content = document.createElement('div');
+  content.id = 'content';
+  document.body.appendChild(content);
+  return content;
+}
+
+/**
  * Renderiza el formulario de matrícula.
  */
 function renderEnrollForm() {
-  const content = $('#content');
+  const content = getContentContainer();
   content.innerHTML = `
     <section class="enroll">
       <h2>Matrícula</h2>
@@ -203,15 +223,22 @@ async function verifyMission(missionId, resultContainer) {
   }
 }
 
-// Al cargar la página index, decide qué mostrar
+// Al cargar la página, decide qué mostrar
 window.addEventListener('load', () => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const forceEnroll = searchParams.has('enroll');
+  if (forceEnroll) {
+    localStorage.removeItem('student_slug');
+    renderEnrollForm();
+    return;
+  }
   const slug = localStorage.getItem('student_slug');
-  if (window.location.pathname.endsWith('index.html') || window.location.pathname === '/') {
-    const forceEnroll = window.location.search.includes('enroll');
-    if (forceEnroll) {
-      localStorage.removeItem('student_slug');
-      renderEnrollForm();
-    } else if (!slug) {
+  if (
+    window.location.pathname.endsWith('index.html') ||
+    window.location.pathname === '/' ||
+    window.location.pathname === ''
+  ) {
+    if (!slug) {
       renderEnrollForm();
     } else {
       loadDashboard();

--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -19,8 +19,8 @@
         </div>
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
-        <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
+        <a class="portal-header__link" href="/index.html">Inicio</a>
+        <a class="portal-header__link" href="/index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -19,8 +19,8 @@
         </div>
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
-        <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
+        <a class="portal-header__link" href="/index.html">Inicio</a>
+        <a class="portal-header__link" href="/index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -19,8 +19,8 @@
         </div>
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
-        <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
+        <a class="portal-header__link" href="/index.html">Inicio</a>
+        <a class="portal-header__link" href="/index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -19,8 +19,8 @@
         </div>
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
-        <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
+        <a class="portal-header__link" href="/index.html">Inicio</a>
+        <a class="portal-header__link" href="/index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -19,8 +19,8 @@
         </div>
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
-        <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
+        <a class="portal-header__link" href="/index.html">Inicio</a>
+        <a class="portal-header__link" href="/index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -19,8 +19,8 @@
         </div>
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
-        <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
+        <a class="portal-header__link" href="/index.html">Inicio</a>
+        <a class="portal-header__link" href="/index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -19,8 +19,8 @@
         </div>
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
-        <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
+        <a class="portal-header__link" href="/index.html">Inicio</a>
+        <a class="portal-header__link" href="/index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -19,8 +19,8 @@
         </div>
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
-        <a class="portal-header__link" href="index.html">Inicio</a>
-        <a class="portal-header__link" href="index.html?enroll">Inscribirme</a>
+        <a class="portal-header__link" href="/index.html">Inicio</a>
+        <a class="portal-header__link" href="/index.html?enroll">Inscribirme</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">


### PR DESCRIPTION
## Summary
- ensure the enrollment flow can render on any HTML page by checking the query string and preparing a content container
- keep mission navigation links pointing to the root index enrollment route so the server does not rewrite URLs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b82b81208331a8e83064d6bca5c2