### PR TITLE
Handle dashboard slug changes and update enroll links

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -89,6 +89,7 @@ function renderEnrollForm() {
  */
 async function loadDashboard() {
   const slug = localStorage.getItem('student_slug');
+  const initialSlug = slug;
   if (!slug) {
     renderEnrollForm();
     return;
@@ -105,6 +106,10 @@ async function loadDashboard() {
     }
     const student = data.student;
     const completed = data.completed || [];
+    const currentSlug = localStorage.getItem('student_slug');
+    if (!currentSlug || currentSlug !== initialSlug) {
+      return;
+    }
     renderDashboard(student, completed);
   } catch (err) {
     content.innerHTML = '<p>Error al obtener el estado del usuario.</p>';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link portal-header__link--active" href="index.html" aria-current="page">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">

--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -22,8 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a
           class="portal-header__link"
-          href="#"
-          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
+          href="/index.html?enroll"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">


### PR DESCRIPTION
## Summary
- capture the initial stored slug when loading the dashboard and abort rendering if it changes before the response arrives
- point every “Inscribirme” header link to `/index.html?enroll` so the enroll parameter is applied consistently

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c8c1a1ead48331b079c1d3249408d2