### PR TITLE
Limit Docker build context to backend and frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,6 @@ env/
 
 # Ignore node modules if accidentally included
 node_modules/
+
+# Legacy directory from previous builds
+portal_educativo/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ COPY backend/requirements.txt ./backend/requirements.txt
 # Install dependencies
 RUN pip install --no-cache-dir -r backend/requirements.txt
 
-# Copy the rest of the project files
-COPY . .
+# Copy application source code explicitly
+COPY backend/ ./backend/
+COPY frontend/ ./frontend/
 
 # Set the port the container will listen on
 ENV PORT 8080


### PR DESCRIPTION
## Summary
- ignore the legacy `portal_educativo` directory so it is not bundled into container builds
- copy only the backend and frontend sources into the Docker image instead of the entire repository

## Testing
- not run (docker CLI not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8c64898fc833181a6b670eb44393f