### PR TITLE
Show enrollment form without reloading

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,8 @@
         <a class="portal-header__link portal-header__link--active" href="index.html" aria-current="page">Inicio</a>
         <a
           class="portal-header__link"
-          href="/index.html?enroll"
+          href="#"
+          onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
           >Inscribirme</a>
       </nav>
       <div class="portal-header__user">


### PR DESCRIPTION
## Summary
- update the "Inscribirme" navigation link to call the enrollment renderer instead of reloading the page

## Testing
- python -m http.server 8000 (manual)
- playwright script to verify the enrollment link shows the form without navigation

------
https://chatgpt.com/codex/tasks/task_e_68c8c79619a88331ae5782b9b174a47c