### PR TITLE
Add login form and landing options to portal

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,6 +25,11 @@
           href="#"
           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;"
           >Inscribirme</a>
+        <a
+          class="portal-header__link"
+          href="#"
+          onclick="localStorage.removeItem('student_slug'); renderLoginForm(); return false;"
+          >Ingresar</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">


### PR DESCRIPTION
## Summary
- add a login form that validates the slug before loading the dashboard
- show entry options on initial load so users can choose to enroll or log in
- expose a navigation link to open the login form and reuse the new entry options on logout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8c9caf6c88331a7a5be9f544dd047