### PR TITLE
Intercept mission link to reopen enrollment form

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -84,6 +84,18 @@ function renderEnrollForm() {
   };
 }
 
+document.addEventListener('DOMContentLoaded', () => {
+  const enrollLink = document.querySelector('a[href="m1.html"]');
+  if (enrollLink) {
+    enrollLink.href = '#';
+    enrollLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      localStorage.removeItem('student_slug');
+      renderEnrollForm();
+    });
+  }
+});
+
 /**
  * Carga el tablero de misiones según el estudiante.
  */


### PR DESCRIPTION
## Summary
- intercept the dynamically generated M1 mission link so it resets local enrollment state and re-renders the form when clicked

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8c9b5a22883318c81f324d043b7ed