### PR TITLE
Intercept enroll link to show form

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -84,6 +84,18 @@ function renderEnrollForm() {
   };
 }
 
+document.addEventListener('DOMContentLoaded', () => {
+  const enrollLink = document.querySelector('a[href="m1.html"]');
+  if (enrollLink) {
+    enrollLink.href = '#';
+    enrollLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      localStorage.removeItem('student_slug');
+      renderEnrollForm();
+    });
+  }
+});
+
 /**
  * Carga el tablero de misiones según el estudiante.
  */


### PR DESCRIPTION
## Summary
- add a DOMContentLoaded listener that intercepts direct Mission 1 links, clears the saved slug, and re-renders the enrollment form
- confirm main.js loads on the mission and index pages so the listener is available wherever the link appears

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8ca57bcec8331b7e359f843f382da