### PR TITLE
Update enroll links to trigger form render

### DIFF
--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -20,10 +20,11 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="/index.html">Inicio</a>
-        <a
-          class="portal-header__link"
-          href="/index.html?enroll"
-          >Inscribirme</a>
+        <a class="portal-header__link"
+           href="#"
+           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+          Inscribirme
+        </a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -20,10 +20,11 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="/index.html">Inicio</a>
-        <a
-          class="portal-header__link"
-          href="/index.html?enroll"
-          >Inscribirme</a>
+        <a class="portal-header__link"
+           href="#"
+           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+          Inscribirme
+        </a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -20,10 +20,11 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="/index.html">Inicio</a>
-        <a
-          class="portal-header__link"
-          href="/index.html?enroll"
-          >Inscribirme</a>
+        <a class="portal-header__link"
+           href="#"
+           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+          Inscribirme
+        </a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -20,10 +20,11 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="/index.html">Inicio</a>
-        <a
-          class="portal-header__link"
-          href="/index.html?enroll"
-          >Inscribirme</a>
+        <a class="portal-header__link"
+           href="#"
+           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+          Inscribirme
+        </a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -20,10 +20,11 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="/index.html">Inicio</a>
-        <a
-          class="portal-header__link"
-          href="/index.html?enroll"
-          >Inscribirme</a>
+        <a class="portal-header__link"
+           href="#"
+           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+          Inscribirme
+        </a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -20,10 +20,11 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="/index.html">Inicio</a>
-        <a
-          class="portal-header__link"
-          href="/index.html?enroll"
-          >Inscribirme</a>
+        <a class="portal-header__link"
+           href="#"
+           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+          Inscribirme
+        </a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -20,10 +20,11 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="/index.html">Inicio</a>
-        <a
-          class="portal-header__link"
-          href="/index.html?enroll"
-          >Inscribirme</a>
+        <a class="portal-header__link"
+           href="#"
+           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+          Inscribirme
+        </a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -20,10 +20,11 @@
       </div>
       <nav class="portal-header__nav" aria-label="Navegación principal">
         <a class="portal-header__link" href="/index.html">Inicio</a>
-        <a
-          class="portal-header__link"
-          href="/index.html?enroll"
-          >Inscribirme</a>
+        <a class="portal-header__link"
+           href="#"
+           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+          Inscribirme
+        </a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">


### PR DESCRIPTION
## Summary
- replace the mission page "Inscribirme" links with a handler that clears the stored student slug and renders the enrollment form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d04c559c83318cf6faa5d28973e0