### PR TITLE
Add students API endpoint and populate login select

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -136,6 +136,18 @@ class PortalHTTPRequestHandler(SimpleHTTPRequestHandler):
                 return
             self._send_json({"student": student, "completed": completed})
             return
+        if path == '/api/students':
+            try:
+                with get_db_connection() as conn:
+                    with conn.cursor(row_factory=dict_row) as cur:
+                        cur.execute('SELECT slug, name FROM students ORDER BY name')
+                        students = [dict(row) for row in cur.fetchall()]
+            except Exception as exc:
+                print(f"Database error on /api/students: {exc}", file=sys.stderr)
+                self._send_json({"error": "Database connection error."}, status=500)
+                return
+            self._send_json({"students": students})
+            return
         # Serve static files
         # Root or index
         if path == '/' or path == '' or path == '/index.html':


### PR DESCRIPTION
## Summary
- add a `/api/students` GET endpoint that returns the registered slugs and names sorted by name
- populate the login form with the student list and trigger the existing login flow when a user is selected

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c93c451000833198fddf52b9d1a083