### PR TITLE
Ensure landing navigation triggers access options

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,10 +23,10 @@
            href="index.html" aria-current="page">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">Inscribirme</a>
+           data-action="enroll">Inscribirme</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderLoginForm(); return false;">Ingresar</a>
+           data-action="login">Ingresar</a>
       </nav>
       <div class="portal-header__user">
         <div class="portal-header__user-info">


### PR DESCRIPTION
## Summary
- add explicit data-action hooks to the landing header links so they invoke the right forms
- initialize access option rendering on initial load (and BFCache restores) when no slug is present
- centralize navigation handler setup for enroll/login actions

## Testing
- Manual verification in browser that the landing page shows both “Matricularme” and “Ya estoy matriculado” options

------
https://chatgpt.com/codex/tasks/task_e_68c94116a9f88331985fa33981a686ae