### PR TITLE
Add registration form and backend handler

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+from flask import Flask, flash, redirect, render_template, request, url_for
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", "dev")
+
+# Almacenamiento sencillo en memoria para usuarios registrados durante
+# el ciclo de vida de la aplicación.
+registered_users: List[Dict[str, str]] = []
+
+
+@app.route("/inscripcion", methods=["GET"])
+def inscripcion() -> str:
+    """Renderiza el formulario de inscripción."""
+    return render_template("inscripcion.html", usuarios=registered_users)
+
+
+@app.route("/register", methods=["POST"])
+def register():
+    """Procesa el formulario de inscripción y almacena al nuevo usuario."""
+    nombre = request.form.get("nombre", "").strip()
+    slug = request.form.get("slug", "").strip()
+    email = request.form.get("email", "").strip()
+
+    if not nombre or not slug or not email:
+        flash("Todos los campos son obligatorios.", "error")
+        return redirect(url_for("inscripcion"))
+
+    registered_users.append({"nombre": nombre, "slug": slug, "email": email})
+    flash("Registro completado correctamente.", "success")
+    return redirect(url_for("inscripcion"))
+
+
+@app.route("/")
+def index() -> str:
+    return redirect(url_for("inscripcion"))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)), debug=True)

--- a/templates/inscripcion.html
+++ b/templates/inscripcion.html
@@ -12,6 +12,37 @@
         <h1>Inscripción</h1>
         <p>Completa el formulario para inscribirte.</p>
       </header>
+
+      {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+      <ul class="messages">
+        {% for category, message in messages %}
+        <li class="message message--{{ category }}">{{ message }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% endwith %}
+
+      <section class="form-section">
+        <form action="{{ url_for('register') }}" method="post" class="registration-form">
+          <div class="form-field">
+            <label for="nombre">Nombre</label>
+            <input type="text" id="nombre" name="nombre" required />
+          </div>
+
+          <div class="form-field">
+            <label for="slug">Slug</label>
+            <input type="text" id="slug" name="slug" required />
+          </div>
+
+          <div class="form-field">
+            <label for="email">Correo electrónico</label>
+            <input type="email" id="email" name="email" required />
+          </div>
+
+          <button type="submit">Registrar</button>
+        </form>
+      </section>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a registration form to the inscription template with client-side validation
- implement Flask routes to render the form and handle POST submissions
- keep in-memory storage of registered users and display feedback messages

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c949014cb883318f66c0196c21e4b1