### PR TITLE
Add login page and backend login view

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,3 @@
+"""PortalKids backend package."""
+
+from .app import app  # noqa: F401

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,83 @@
+"""PortalKids web application entry-point."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from flask import Flask, redirect, render_template, request, url_for
+
+app = Flask(__name__)
+
+# Datos de ejemplo para las misiones disponibles en el portal.
+MISSIONS: List[Dict[str, str]] = [
+    {
+        "title": "Exploración de la Nebulosa Aurora",
+        "description": "Recolecta muestras de partículas luminosas para el laboratorio.",
+        "status": "Activa",
+        "due_date": "2024-09-30",
+        "location": "Sector Boreal",
+    },
+    {
+        "title": "Rescate del Satélite Eco",
+        "description": "Ayuda a reparar el satélite de comunicaciones Eco antes de que se apague.",
+        "status": "Urgente",
+        "due_date": "2024-08-18",
+        "location": "Órbita Sincrónica",
+    },
+    {
+        "title": "Cartografía del Cinturón Prisma",
+        "description": "Crea un mapa detallado del campo de asteroides Prisma con la tripulación.",
+        "status": "Programada",
+        "due_date": "2024-11-05",
+        "location": "Cinturón Prisma",
+    },
+]
+
+# Credenciales mínimas para validar el acceso al portal.
+CREW_MEMBERS: Dict[str, Dict[str, str]] = {
+    "capitana-nova": {"password": "orbita"},
+    "piloto-cometa": {"password": "halo"},
+    "especialista-quantum": {"password": "quasar"},
+}
+
+
+def _normalize_slug(value: str) -> str:
+    """Normaliza el identificador recibido desde el formulario."""
+
+    return value.strip().lower()
+
+
+@app.route("/", methods=["GET", "POST"])
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    """Muestra el formulario de acceso y valida las credenciales enviadas."""
+
+    error = None
+    if request.method == "POST":
+        slug = _normalize_slug(request.form.get("slug", ""))
+        password = request.form.get("password", "")
+
+        member = CREW_MEMBERS.get(slug)
+        if member and password == member.get("password"):
+            return redirect(url_for("missions", slug=slug))
+
+        error = "Usuario o contraseña incorrectos. Inténtalo nuevamente."
+
+    return render_template("login.html", error=error)
+
+
+@app.route("/inscripcion", methods=["GET"])
+def inscripcion():
+    """Renderiza la página de inscripción existente."""
+
+    return render_template("inscripcion.html")
+
+
+@app.route("/misiones", methods=["GET"])
+def missions():
+    """Muestra el tablero con las misiones disponibles."""
+
+    return render_template("missions.html", missions=MISSIONS)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -125,3 +125,115 @@ a:focus {
     padding: 1.5rem;
   }
 }
+
+.form-card {
+  background-color: #1e1e1e;
+  border-radius: 18px;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.form-field label {
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.form-field input {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  background: rgba(18, 18, 18, 0.9);
+  color: #f5f5f5;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus {
+  outline: none;
+  border-color: rgba(128, 216, 255, 0.8);
+  box-shadow: 0 0 0 3px rgba(128, 216, 255, 0.25);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.8rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, #4fc3f7, #29b6f6);
+  color: #0a0a0a;
+  box-shadow: 0 12px 24px rgba(79, 195, 247, 0.35);
+}
+
+.button-primary:hover,
+.button-primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(79, 195, 247, 0.45);
+}
+
+.button-secondary {
+  background: transparent;
+  color: #80d8ff;
+  border: 1px solid rgba(128, 216, 255, 0.4);
+}
+
+.button-secondary:hover,
+.button-secondary:focus {
+  transform: translateY(-2px);
+  border-color: rgba(128, 216, 255, 0.8);
+  box-shadow: 0 12px 24px rgba(128, 216, 255, 0.2);
+}
+
+.form-error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  background: rgba(244, 67, 54, 0.15);
+  color: #ff8a80;
+  border: 1px solid rgba(244, 67, 54, 0.4);
+  border-radius: 12px;
+}
+
+@media (max-width: 480px) {
+  .form-card {
+    padding: 1.5rem;
+  }
+
+  .form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .form-actions .button {
+    width: 100%;
+  }
+}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Acceso al Portal</title>
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/main.css') }}"
+    />
+  </head>
+  <body>
+    <main class="page-container">
+      <header class="page-header">
+        <h1>Portal de la Tripulación</h1>
+        <p>Inicia sesión con tu identificador espacial para continuar.</p>
+      </header>
+
+      <section aria-label="Formulario de acceso" class="form-card">
+        <form method="post" class="form-grid">
+          <div class="form-field">
+            <label for="slug">Identificador</label>
+            <input
+              type="text"
+              id="slug"
+              name="slug"
+              placeholder="capitana-nova"
+              required
+              autocomplete="username"
+            />
+          </div>
+
+          <div class="form-field">
+            <label for="password">Contraseña</label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              placeholder="••••••••"
+              required
+              autocomplete="current-password"
+            />
+          </div>
+
+          {% if error %}
+          <p class="form-error" role="alert">{{ error }}</p>
+          {% endif %}
+
+          <div class="form-actions">
+            <button type="submit" class="button button-primary">Entrar</button>
+            <a class="button button-secondary" href="{{ url_for('inscripcion') }}"
+              >Registrarse</a
+            >
+          </div>
+        </form>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask application module with login, missions, and inscripción routes backed by sample data
- provide a login template and styles with a registration link to the existing route
- update shared styles to support the new authentication form

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c948fe2e50833197c296ce5cf2744f