### PR TITLE
Add Flask backend with authentication and mission routes

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from flask import Flask, render_template
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+app = Flask(
+    __name__,
+    template_folder=str(BASE_DIR / "templates"),
+    static_folder=str(BASE_DIR / "static"),
+)
+
+
+@app.route("/login")
+def login():
+    """Renderiza la página de inicio de sesión."""
+    return render_template("login.html")
+
+
+@app.route("/register")
+def register():
+    """Renderiza la página de registro."""
+    return render_template("inscripcion.html")
+
+
+@app.route("/missions")
+def missions():
+    """Renderiza el listado de misiones disponibles."""
+    missions_data = [
+        {
+            "title": "Limpieza de paneles solares",
+            "description": "Asegura el máximo rendimiento energético limpiando los paneles principales.",
+            "status": "Disponible",
+            "due_date": "2024-07-01",
+            "location": "Módulo exterior Alfa",
+            "link": True,
+        },
+        {
+            "title": "Mantenimiento del sistema de oxígeno",
+            "description": "Revisa los niveles y filtros del sistema de soporte vital.",
+            "status": "En curso",
+            "due_date": "2024-06-15",
+            "location": "Laboratorio central",
+            "link": True,
+        },
+        {
+            "title": "Exploración geológica",
+            "description": "Recolecta muestras de la superficie para analizarlas en el laboratorio.",
+            "status": "Próximamente",
+            "due_date": "2024-08-10",
+            "location": "Sector Delta",
+            "link": False,
+        },
+    ]
+    return render_template("missions.html", missions=missions_data)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Iniciar sesión</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+  </head>
+  <body>
+    <main class="page-container">
+      <header class="page-header">
+        <h1>Inicia sesión</h1>
+        <p>Accede a tu cuenta para continuar la aventura.</p>
+      </header>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask application module under `backend/` configured to serve the existing templates
- implement `/login`, `/register`, and `/missions` routes with sample mission data for rendering
- create a simple `login.html` template to accompany the new login route

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c949045c308331b4280da194ddc256