### PR TITLE
Add email and password fields to enrollment form

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -37,6 +37,8 @@ function renderEnrollForm() {
       <p>Ingresa tus datos para comenzar.</p>
       <form id="enrollForm">
         <label>Nombre:<br /><input type="text" id="name" required /></label><br />
+        <label>Correo electrónico:<br /><input type="email" id="email" required /></label><br />
+        <label>Contraseña:<br /><input type="password" id="password" required /></label><br />
         <label>Slug (sin espacios, ej: juan-perez):<br /><input type="text" id="slug" required /></label><br />
         <label>Rol:<br />
           <select id="role" required>
@@ -53,10 +55,12 @@ function renderEnrollForm() {
   $('#enrollForm').onsubmit = async (e) => {
     e.preventDefault();
     const name = $('#name').value.trim();
+    const email = $('#email').value.trim();
+    const password = $('#password').value;
     const slug = $('#slug').value.trim();
     const role = $('#role').value;
     const workdir = $('#workdir').value.trim();
-    if (!name || !slug || !role || !workdir) {
+    if (!name || !email || !password || !slug || !role || !workdir) {
       $('#enrollMsg').textContent = 'Todos los campos son obligatorios.';
       return;
     }
@@ -66,7 +70,7 @@ function renderEnrollForm() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ name, slug, role, workdir }),
+        body: JSON.stringify({ name, email, password, slug, role, workdir }),
       });
       const data = await res.json();
       if (res.ok) {


### PR DESCRIPTION
## Summary
- add email and password inputs to the enrollment form and ensure they are required
- include the new credentials in the `/api/enroll` request payload while retaining role and workdir fields that are still used elsewhere

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9512729c08331ad644e8d0c616610