### PR TITLE
Add credential login flow and migration

### DIFF
--- a/backend/migrations/001_add_student_credentials.sql
+++ b/backend/migrations/001_add_student_credentials.sql
@@ -1,0 +1,4 @@
+ALTER TABLE students
+    ADD COLUMN IF NOT EXISTS email TEXT;
+ALTER TABLE students
+    ADD COLUMN IF NOT EXISTS password_hash TEXT;


### PR DESCRIPTION
## Summary
- add an explicit SQL migration that adds the email and password_hash columns to students
- extend the /api/login handler to validate hashes and return completed missions along with the session token
- update the enrollment and login UI flows to rely on /api/login data (token, student, completed missions) instead of fetching /api/status immediately

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c980c1e3988331863685f82a497f40