### PR TITLE
Add enrollment route and mission card link

### DIFF
--- a/frontend/src/components/MissionCard.jsx
+++ b/frontend/src/components/MissionCard.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const MissionCard = ({ mission = {} }) => {
+  const missionIdentifier = mission.slug || mission.id;
+  const enrollmentTarget = missionIdentifier
+    ? `/inscripcion/${missionIdentifier}`
+    : '#';
+  const title = mission.title || mission.name || 'Misión sin título';
+
+  return (
+    <article className="mission-card">
+      <Link to={enrollmentTarget} className="mission-card__link">
+        <header className="mission-card__header">
+          <h3 className="mission-card__title">{title}</h3>
+        </header>
+        {mission.summary && (
+          <p className="mission-card__summary">{mission.summary}</p>
+        )}
+        {mission.description && (
+          <p className="mission-card__description">{mission.description}</p>
+        )}
+      </Link>
+    </article>
+  );
+};
+
+export default MissionCard;

--- a/frontend/src/pages/EnrollPage.jsx
+++ b/frontend/src/pages/EnrollPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const EnrollPage = () => (
+  <section className="enroll-page">
+    <h1>Matrícula de misión</h1>
+    <p>Completa el proceso de matrícula para unirte a la misión seleccionada.</p>
+  </section>
+);
+
+export default EnrollPage;

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import EnrollPage from '../pages/EnrollPage';
+
+const AppRouter = () => (
+  <Routes>
+    <Route path="/" element={<div>Inicio del portal</div>} />
+    <Route path="/misiones/:missionId" element={<div>Detalle de la misión</div>} />
+    <Route path="/inscripcion/:missionId" element={<EnrollPage />} />
+  </Routes>
+);
+
+export default AppRouter;


### PR DESCRIPTION
## Summary
- render mission cards as react-router links that point to the enrollment path for each mission
- register an `/inscripcion/:missionId` route and provide a basic enrollment page placeholder

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c997bc24388331ba9a2635699342b5