### PR TITLE
Ensure secure session handling across backend and frontend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -304,12 +304,15 @@ def _get_env_bool(name: str, default: bool = False) -> bool:
 
 
 app = Flask(__name__, static_folder="../frontend", static_url_path="/")
-app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", secrets.token_hex(16))
-app.config["SESSION_COOKIE_HTTPONLY"] = _get_env_bool(
-    "SESSION_COOKIE_HTTPONLY", True
-)
-app.config["SESSION_COOKIE_SECURE"] = _get_env_bool("SESSION_COOKIE_SECURE", False)
-app.config["SESSION_COOKIE_SAMESITE"] = os.environ.get("SESSION_COOKIE_SAMESITE", "Lax")
+secret_key = os.environ.get("SECRET_KEY")
+if not secret_key:
+    raise RuntimeError(
+        "SECRET_KEY environment variable must be set before starting the application."
+    )
+app.config["SECRET_KEY"] = secret_key
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SECURE"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "None"
 app.config["SESSION_COOKIE_PATH"] = os.environ.get("SESSION_COOKIE_PATH", "/")
 app.config["SESSION_COOKIE_NAME"] = os.environ.get("SESSION_COOKIE_NAME", "session")
 

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -97,6 +97,7 @@ function renderEnrollForm() {
     try {
       const res = await fetch('/api/enroll', {
         method: 'POST',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -108,6 +109,7 @@ function renderEnrollForm() {
         try {
           const loginRes = await fetch('/api/login', {
             method: 'POST',
+            credentials: 'include',
             headers: {
               'Content-Type': 'application/json',
             },
@@ -196,6 +198,7 @@ function renderLoginForm() {
     try {
       const res = await fetch('/api/login', {
         method: 'POST',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -262,7 +265,9 @@ function renderLoginForm() {
     };
     (async () => {
       try {
-        const res = await fetch('/api/students');
+        const res = await fetch('/api/students', {
+          credentials: 'include',
+        });
         if (!res.ok) {
           throw new Error('Failed to load students');
         }
@@ -313,6 +318,7 @@ async function loadDashboard() {
         }
       : {};
     const res = await fetch(`/api/status?slug=${encodeURIComponent(slug)}`, {
+      credentials: 'include',
       headers,
     });
     let data = {};
@@ -488,6 +494,7 @@ async function verifyMission(missionId, resultContainer) {
   try {
     const res = await fetch('/api/verify_mission', {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),


### PR DESCRIPTION
## Summary
- require SECRET_KEY to be provided via environment configuration and harden Flask session cookie settings
- include credentials with frontend fetch requests involved in authentication to support cookie-based sessions

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c99c843d708331b144b0e14facb209