### PR TITLE
Update Docker CMD to expand PORT variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY frontend/ ./frontend/
 
 EXPOSE 8080
 
-CMD ["gunicorn", "-w", "2", "-k", "gthread", "-b", "0.0.0.0:${PORT}", "backend.wsgi:app"]
+CMD ["sh", "-c", "exec gunicorn -w ${WEB_CONCURRENCY:-2} -k gthread -b 0.0.0.0:${PORT:-8080} backend.wsgi:app"]


### PR DESCRIPTION
## Summary
- switch the Dockerfile CMD to a shell form so the PORT environment variable expands at runtime
- ensure Gunicorn defaults to binding on 0.0.0.0:${PORT:-8080}

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9a0ebd33c833198526a760c35bade