### PR TITLE
Add Flask-Cors dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.3.2
+Flask-Cors==3.0.10
 PyYAML==6.0
 gunicorn==20.1.0
 psycopg[binary]==3.1.12


### PR DESCRIPTION
## Summary
- add Flask-Cors package to the backend requirements list so it is installed with the service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9a67dcb2083319225cdb2ecf4b08e