### PR TITLE
Ensure backend package importability and script-friendly WSGI entrypoint

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""PortalKids backend package."""

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,7 +1,13 @@
 import os
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    project_root = str(Path(__file__).resolve().parent.parent)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
 
 from backend.app import app
-
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", "8080"))


### PR DESCRIPTION
## Summary
- add a package module docstring so ``backend`` is explicitly recognized as a package
- update the WSGI entrypoint to adjust ``sys.path`` when executed directly, allowing script execution without the ``backend.`` prefix

## Testing
- python -m compileall backend/wsgi.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b600f0b48331a2f7dc00277fa6f8