### PR TITLE
Fix enrollment links and clean mission markup

### DIFF
--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -1,5 +1,4 @@
-<renderEnroll
-!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="UTF-8" />
@@ -23,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStoratestge.removeItem('student_slug'); renderEnrollForm(); return false;">
+           onclick="localStorage.setItem('student_slug', 'm1'); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -1,5 +1,4 @@
-<renderEnrollForm
-!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="UTF-8" />
@@ -23,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           onclick="localStorage.setItem('student_slug', 'm2'); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           onclick="localStorage.setItem('student_slug', 'm3'); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           onclick="localStorage.setItem('student_slug', 'm4'); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           onclick="localStorage.setItem('student_slug', 'm5'); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           onclick="localStorage.setItem('student_slug', 'm6o'); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           onclick="localStorage.setItem('student_slug', 'm6v'); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           onclick="localStorage.setItem('student_slug', 'm7'); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>


### PR DESCRIPTION
## Summary
- restore a valid DOCTYPE at the top of the M1 and M2 mission pages and remove stray tags
- update every "Inscribirme" link to persist the relevant mission slug before rendering the enrollment form
- fix the localStorage typo on the M1 mission page

## Testing
- not run (HTML changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c9b790989c8331b29143b082bc7c0d