### PR TITLE
Switch backend to MySQL connector

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,5 +2,5 @@ Flask==2.3.2
 Flask-Cors==3.0.10
 PyYAML==6.0
 gunicorn==20.1.0
-psycopg[binary]==3.1.12
+PyMySQL==1.1.0
 bcrypt==4.0.1


### PR DESCRIPTION
## Summary
- replace the psycopg dependency with PyMySQL and configure the connection for MySQL defaults
- update the database initialization and CRUD statements to match MySQL types and upsert semantics
- add PyMySQL to the backend requirements list

## Testing
- python -m py_compile backend/app.py
- python - <<'PY'
from backend.app import get_db_connection
try:
    with get_db_connection() as conn:
        with conn.cursor() as cur:
            cur.execute("SELECT 1")
            print(cur.fetchone())
except Exception as exc:
    print('error', exc)
PY

------
https://chatgpt.com/codex/tasks/task_e_68c9deec84c4833183fd0b0adf889cd4