### PR TITLE
Add GitHub-backed mission verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ Variables opcionales:
 | `DB_CONNECT_TIMEOUT` | Tiempo máximo de conexión en segundos. |
 
 Debes proporcionar `DB_HOST` o `DB_INSTANCE_CONNECTION_NAME`; si falta alguno el backend devolverá un error 500 al atender las peticiones.
+
+## Integración con repositorios remotos en GitHub
+
+La verificación automática de misiones se realiza leyendo los archivos del estudiante directamente desde GitHub. Configura las siguientes variables de entorno antes de iniciar el backend:
+
+| Variable | Descripción |
+| --- | --- |
+| `GITHUB_TOKEN` | Token personal con permiso de lectura sobre los repositorios. |
+| `GITHUB_VENTAS_REPO` | Repositorio (formato `owner/nombre`) donde trabajan los estudiantes del track de Ventas. |
+| `GITHUB_OPERACIONES_REPO` | Repositorio (formato `owner/nombre`) para el track de Operaciones. |
+| `GITHUB_VENTAS_BRANCH` | Rama por defecto a utilizar para Ventas (opcional, `main` si no se define). |
+| `GITHUB_OPERACIONES_BRANCH` | Rama por defecto para Operaciones (opcional, `main` si no se define). |
+| `GITHUB_API_URL` | URL base de la API de GitHub (opcional, útil para GitHub Enterprise). |
+| `GITHUB_TIMEOUT` | Tiempo máximo en segundos para cada descarga desde GitHub (opcional, por defecto `10`). |
+
+El backend identifica qué repositorio debe revisar cada estudiante usando su `slug` o el `role` registrado (`ventas`, `operaciones`, sufijos `_v`/`_o`, etc.). En `backend/missions_contracts.json` cada misión incluye una sección `source` con la plantilla de ruta base (`students/{slug}`) y el repositorio objetivo (`default`, `ventas` u `operaciones`). Durante la verificación se descargan únicamente los archivos declarados en el contrato y, en el caso de scripts, se copian a un directorio temporal antes de ejecutarlos.
+
+Si GitHub devuelve un error o el archivo solicitado no existe, la API responde con `verified: false` y un mensaje de retroalimentación indicando qué archivo falló y en qué repositorio se buscó. Esto permite que el estudiante ajuste su entrega sin necesidad de revisar los logs del servidor.

--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -1,0 +1,293 @@
+"""Helpers to resolve student mission files directly from GitHub."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict
+from urllib.parse import quote
+
+import requests
+
+
+class GitHubConfigurationError(RuntimeError):
+    """Raised when GitHub integration is misconfigured."""
+
+
+class GitHubDownloadError(RuntimeError):
+    """Raised when a download from GitHub fails unexpectedly."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        repository: str | None = None,
+        path: str | None = None,
+        ref: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.repository = repository
+        self.path = path
+        self.ref = ref
+
+
+class GitHubFileNotFoundError(FileNotFoundError):
+    """Raised when a file cannot be found in the configured repository."""
+
+    def __init__(self, message: str, *, repository: str, path: str, ref: str) -> None:
+        super().__init__(message)
+        self.repository = repository
+        self.path = path
+        self.ref = ref
+
+
+@dataclass(frozen=True)
+class RepositoryInfo:
+    key: str
+    repository: str
+    default_branch: str
+
+
+@dataclass(frozen=True)
+class RepositorySelection:
+    info: RepositoryInfo
+    branch: str
+    base_path: str
+
+    def resolve_path(self, relative_path: str) -> str:
+        relative = (relative_path or "").strip("/")
+        base = (self.base_path or "").strip("/")
+        if base and relative:
+            return f"{base}/{relative}"
+        if base:
+            return base
+        return relative
+
+
+class GitHubClient:
+    """Thin wrapper around the GitHub Contents API."""
+
+    def __init__(self, token: str, api_url: str = "https://api.github.com", timeout: float = 10.0) -> None:
+        if not token:
+            raise GitHubConfigurationError(
+                "Configura la variable de entorno GITHUB_TOKEN para habilitar la verificación remota."
+            )
+        self.api_url = api_url.rstrip("/")
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "User-Agent": os.environ.get("GITHUB_USER_AGENT", "PortalKidsVerifier/1.0"),
+            }
+        )
+
+    @classmethod
+    def from_env(cls) -> "GitHubClient":
+        token = os.environ.get("GITHUB_TOKEN")
+        api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+        timeout_value = os.environ.get("GITHUB_TIMEOUT", "10")
+        try:
+            timeout = float(timeout_value)
+        except (TypeError, ValueError):
+            timeout = 10.0
+        return cls(token=token or "", api_url=api_url, timeout=timeout)
+
+    def get_file_content(self, repository: str, path: str, ref: str | None) -> bytes:
+        if not repository:
+            raise GitHubConfigurationError("El repositorio de GitHub no está configurado.")
+        clean_path = (path or "").strip("/")
+        if not clean_path:
+            raise GitHubConfigurationError("La ruta solicitada al repositorio de GitHub está vacía.")
+        quoted_path = quote(clean_path, safe="/")
+        url = f"{self.api_url}/repos/{repository}/contents/{quoted_path}"
+        params = {"ref": ref} if ref else None
+        headers = {"Accept": "application/vnd.github.v3.raw"}
+        try:
+            response = self._session.get(url, params=params, headers=headers, timeout=self.timeout)
+        except requests.RequestException as exc:
+            raise GitHubDownloadError(
+                f"No se pudo conectar con GitHub para leer {repository}:{clean_path}: {exc}",
+                repository=repository,
+                path=clean_path,
+                ref=ref or "",
+            ) from exc
+        if response.status_code == 404:
+            raise GitHubFileNotFoundError(
+                f"No se encontró {repository}:{clean_path} en la rama {ref or 'predeterminada'}.",
+                repository=repository,
+                path=clean_path,
+                ref=ref or "",
+            )
+        if response.status_code >= 400:
+            details: str
+            try:
+                payload = response.json()
+                details = payload.get("message") or response.text
+            except ValueError:
+                details = response.text
+            raise GitHubDownloadError(
+                (
+                    f"GitHub respondió {response.status_code} al leer "
+                    f"{repository}:{clean_path} (rama {ref or 'predeterminada'}): {details}"
+                ),
+                repository=repository,
+                path=clean_path,
+                ref=ref or "",
+            )
+        return response.content
+
+
+def determine_student_repositories(slug: str, role: str | None = None) -> Dict[str, RepositoryInfo]:
+    slug_lower = (slug or "").lower()
+    role_lower = (role or "").lower()
+
+    keys: list[str] = []
+    if _matches_ventas(slug_lower) or _matches_ventas(role_lower):
+        keys.append("ventas")
+    if _matches_operaciones(slug_lower) or _matches_operaciones(role_lower):
+        keys.append("operaciones")
+
+    if not keys:
+        keys = [key for key in ("ventas", "operaciones") if _env_repository_configured(key)]
+
+    repositories: Dict[str, RepositoryInfo] = {}
+    for key in keys:
+        info = _build_repository_info(key)
+        repositories[key] = info
+
+    if not repositories:
+        raise GitHubConfigurationError(
+            "No hay repositorios de GitHub configurados para el estudiante. "
+            "Verifica las variables GITHUB_VENTAS_REPO y GITHUB_OPERACIONES_REPO."
+        )
+    return repositories
+
+
+def select_repository_for_contract(
+    source_config: dict | None,
+    slug: str,
+    repositories: Dict[str, RepositoryInfo],
+) -> RepositorySelection:
+    source = source_config or {}
+    requested_key = (source.get("repository") or "default").lower()
+
+    if requested_key == "default":
+        if len(repositories) == 1:
+            info = next(iter(repositories.values()))
+        elif "ventas" in repositories:
+            info = repositories["ventas"]
+        elif "operaciones" in repositories:
+            info = repositories["operaciones"]
+        else:
+            info = next(iter(repositories.values()))
+    else:
+        info = repositories.get(requested_key)
+        if not info:
+            raise GitHubConfigurationError(
+                f"El contrato requiere el repositorio '{requested_key}', pero el estudiante no lo tiene asignado."
+            )
+
+    branch_env = source.get("branch_env")
+    branch_override = os.environ.get(branch_env, "") if branch_env else ""
+    branch = branch_override or source.get("branch") or source.get("default_branch") or info.default_branch
+
+    base_path_template = source.get("base_path", "") or ""
+    try:
+        formatted_base = base_path_template.format(slug=slug)
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise GitHubConfigurationError(
+            f"La plantilla de ruta base '{base_path_template}' es inválida: falta la clave {exc}."
+        ) from exc
+    base_path = (formatted_base or "").strip("/")
+
+    return RepositorySelection(info=info, branch=branch or info.default_branch, base_path=base_path)
+
+
+class RepositoryFileAccessor:
+    """Provides convenience helpers to access files in a remote repository."""
+
+    def __init__(self, client: GitHubClient, selection: RepositorySelection) -> None:
+        self._client = client
+        self._selection = selection
+        self._cache: Dict[str, bytes] = {}
+
+    @property
+    def repository(self) -> str:
+        return self._selection.info.repository
+
+    @property
+    def branch(self) -> str:
+        return self._selection.branch
+
+    def describe_source(self, relative_path: str | None = None) -> str:
+        base = f"{self.repository} (rama {self.branch})"
+        if relative_path is None:
+            return base
+        remote_path = self._selection.resolve_path(relative_path)
+        if remote_path:
+            return f"{base} en {remote_path}"
+        return base
+
+    def read_bytes(self, relative_path: str) -> bytes:
+        remote_path = self._selection.resolve_path(relative_path)
+        if remote_path in self._cache:
+            return self._cache[remote_path]
+        content = self._client.get_file_content(self.repository, remote_path, self.branch)
+        self._cache[remote_path] = content
+        return content
+
+    def read_text(self, relative_path: str) -> str:
+        return self.read_bytes(relative_path).decode("utf-8")
+
+    def exists(self, relative_path: str) -> bool:
+        try:
+            self.read_bytes(relative_path)
+        except GitHubFileNotFoundError:
+            return False
+        return True
+
+    def resolve_remote_path(self, relative_path: str) -> str:
+        return self._selection.resolve_path(relative_path)
+
+
+def _matches_ventas(text: str) -> bool:
+    if not text:
+        return False
+    return any(
+        token in text
+        for token in (
+            "ventas",
+            "venta",
+            "sales",
+        )
+    ) or text.endswith("-v") or text.endswith("_v") or text.endswith("v")
+
+
+def _matches_operaciones(text: str) -> bool:
+    if not text:
+        return False
+    return any(
+        token in text
+        for token in (
+            "oper",
+            "ops",
+            "operaciones",
+        )
+    ) or text.endswith("-o") or text.endswith("_o") or text.endswith("o")
+
+
+def _env_repository_configured(key: str) -> bool:
+    env_name = f"GITHUB_{key.upper()}_REPO"
+    return bool(os.environ.get(env_name))
+
+
+def _build_repository_info(key: str) -> RepositoryInfo:
+    repo_env = f"GITHUB_{key.upper()}_REPO"
+    repo_value = (os.environ.get(repo_env) or "").strip()
+    if not repo_value:
+        raise GitHubConfigurationError(
+            f"Configura la variable de entorno {repo_env} para habilitar el repositorio '{key}'."
+        )
+    branch_env = f"GITHUB_{key.upper()}_BRANCH"
+    default_branch = (os.environ.get(branch_env) or "main").strip() or "main"
+    return RepositoryInfo(key=key, repository=repo_value, default_branch=default_branch)

--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -1,6 +1,11 @@
 {
   "m1": {
     "verification_type": "evidence",
+    "source": {
+      "repository": "default",
+      "default_branch": "main",
+      "base_path": "students/{slug}"
+    },
     "deliverables": [
       {
         "type": "file_exists",
@@ -22,6 +27,11 @@
   },
   "m2": {
     "verification_type": "evidence",
+    "source": {
+      "repository": "default",
+      "default_branch": "main",
+      "base_path": "students/{slug}"
+    },
     "deliverables": [
       {
         "type": "file_exists",
@@ -48,6 +58,11 @@
   },
   "m3": {
     "verification_type": "script_output",
+    "source": {
+      "repository": "default",
+      "default_branch": "main",
+      "base_path": "students/{slug}"
+    },
     "script_path": "scripts/m3_explorer.py",
     "validations": [
       {
@@ -64,6 +79,11 @@
   },
   "m4": {
     "verification_type": "evidence",
+    "source": {
+      "repository": "default",
+      "default_branch": "main",
+      "base_path": "students/{slug}"
+    },
     "deliverables": [
       {
         "type": "file_exists",
@@ -79,12 +99,22 @@
   },
   "m5": {
     "verification_type": "llm_evaluation",
+    "source": {
+      "repository": "default",
+      "default_branch": "main",
+      "base_path": "students/{slug}"
+    },
     "deliverable_path": "docs/m5_notes.md",
     "expected_keywords": ["limpieza", "tipos", "duplicados"],
     "feedback_fail": "La evaluación automática de tus notas indica que necesitan más detalle o claridad en limpieza, tipos y duplicados."
   },
   "m6v": {
     "verification_type": "evidence",
+    "source": {
+      "repository": "ventas",
+      "default_branch": "main",
+      "base_path": "students/{slug}"
+    },
     "deliverables": [
       {
         "type": "file_exists",
@@ -105,6 +135,11 @@
   },
   "m6o": {
     "verification_type": "evidence",
+    "source": {
+      "repository": "operaciones",
+      "default_branch": "main",
+      "base_path": "students/{slug}"
+    },
     "deliverables": [
       {
         "type": "file_exists",
@@ -125,6 +160,11 @@
   },
   "m7": {
     "verification_type": "evidence",
+    "source": {
+      "repository": "default",
+      "default_branch": "main",
+      "base_path": "students/{slug}"
+    },
     "deliverables": [
       {
         "type": "file_exists",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ PyYAML==6.0
 gunicorn==20.1.0
 PyMySQL==1.1.0
 bcrypt==4.0.1
+requests==2.31.0


### PR DESCRIPTION
## Summary
- add a GitHub client helper to resolve student repositories and download mission files
- update mission verification to consume remote file content and surface download errors
- extend mission contracts, documentation and requirements with repository metadata and GitHub configuration

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c9fa0c95208331a487e3c9d086c311