### PR TITLE
Persist sessions in shared database storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Variables opcionales:
 
 Debes proporcionar `DB_HOST` o `DB_INSTANCE_CONNECTION_NAME`; si falta alguno el backend devolverá un error 500 al atender las peticiones.
 
+### Gestión de sesiones
+
+El backend persiste las sesiones de autenticación en la tabla `sessions` de la misma base de datos. Aplica las migraciones SQL en `backend/migrations/` (incluyendo `003_create_sessions_table.sql`) para crearla con las columnas `token`, `student_slug` y `created_at`, donde `token` actúa como clave primaria e índice para las búsquedas.
+
+Cuando un estudiante inicia sesión, `create_session` inserta una fila nueva con un token firmado aleatorio y marca la hora de creación con `UTC_TIMESTAMP()`. Cada llamada a `validate_session` consulta la tabla y elimina automáticamente los registros cuya antigüedad supere las ocho horas (`SESSION_DURATION_SECONDS`). Cuando se implemente un endpoint de cierre de sesión bastará con borrar la fila correspondiente (`DELETE FROM sessions WHERE token = ?`) para invalidar el token también en el resto de instancias.
+
 ## Integración con repositorios remotos en GitHub
 
 La verificación automática de misiones se realiza leyendo los archivos del estudiante directamente desde GitHub. Configura las siguientes variables de entorno antes de iniciar el backend:

--- a/backend/migrations/003_create_sessions_table.sql
+++ b/backend/migrations/003_create_sessions_table.sql
@@ -1,0 +1,12 @@
+-- Creates persistent storage for login sessions.
+CREATE TABLE IF NOT EXISTS sessions (
+    token VARCHAR(255) NOT NULL,
+    student_slug VARCHAR(255) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (token),
+    KEY idx_sessions_student_slug (student_slug),
+    CONSTRAINT fk_sessions_student_slug
+        FOREIGN KEY (student_slug)
+        REFERENCES students (slug)
+        ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- add a `sessions` table to the database bootstrap and store login tokens there instead of in memory
- purge expired rows when creating or validating sessions and surface errors when issuing tokens
- document the new session storage flow and ship a SQL migration to create the table

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ca01d2fb2883319d5e4132196e9a07