### PR TITLE
Fix enrollment slug reset on mission pages

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -4,6 +4,7 @@ const API_BASE = '';
 const STORAGE_KEYS = {
   slug: 'student_slug',
   token: 'session_token',
+  mission: 'current_mission',
 };
 
 function storeSession(slug, token) {
@@ -20,6 +21,22 @@ function storeSession(slug, token) {
 function clearSession() {
   localStorage.removeItem(STORAGE_KEYS.slug);
   localStorage.removeItem(STORAGE_KEYS.token);
+}
+
+function setCurrentMission(missionId) {
+  if (missionId) {
+    localStorage.setItem(STORAGE_KEYS.mission, missionId);
+    return;
+  }
+  localStorage.removeItem(STORAGE_KEYS.mission);
+}
+
+function getCurrentMission() {
+  return localStorage.getItem(STORAGE_KEYS.mission);
+}
+
+function clearCurrentMission() {
+  localStorage.removeItem(STORAGE_KEYS.mission);
 }
 
 function getStoredSlug() {
@@ -59,9 +76,19 @@ function getContentContainer() {
  */
 function renderEnrollForm() {
   const content = getContentContainer();
+  const missionId = getCurrentMission();
+  let missionNotice = '';
+  if (missionId) {
+    const safeMissionId = missionId.replace(/[^a-z0-9_-]/gi, '').toUpperCase();
+    if (safeMissionId) {
+      missionNotice = `<p class="enroll__current-mission">Estás iniciando tu matrícula desde la misión <strong>${safeMissionId}</strong>.</p>`;
+    }
+  }
+  clearCurrentMission();
   content.innerHTML = `
     <section class="enroll">
       <h2>Matrícula</h2>
+      ${missionNotice}
       <p>Ingresa tus datos para comenzar.</p>
       <form id="enrollForm">
         <label>Nombre:<br /><input type="text" id="name" required /></label><br />

--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.setItem('student_slug', 'm1'); renderEnrollForm(); return false;">
+           onclick="setCurrentMission('m1'); clearSession(); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.setItem('student_slug', 'm2'); renderEnrollForm(); return false;">
+           onclick="setCurrentMission('m2'); clearSession(); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.setItem('student_slug', 'm3'); renderEnrollForm(); return false;">
+           onclick="setCurrentMission('m3'); clearSession(); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.setItem('student_slug', 'm4'); renderEnrollForm(); return false;">
+           onclick="setCurrentMission('m4'); clearSession(); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.setItem('student_slug', 'm5'); renderEnrollForm(); return false;">
+           onclick="setCurrentMission('m5'); clearSession(); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.setItem('student_slug', 'm6o'); renderEnrollForm(); return false;">
+           onclick="setCurrentMission('m6o'); clearSession(); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.setItem('student_slug', 'm6v'); renderEnrollForm(); return false;">
+           onclick="setCurrentMission('m6v'); clearSession(); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.setItem('student_slug', 'm7'); renderEnrollForm(); return false;">
+           onclick="setCurrentMission('m7'); clearSession(); renderEnrollForm(); return false;">
           Inscribirme
         </a>
       </nav>


### PR DESCRIPTION
## Summary
- track the selected mission separately from the stored student session when opening enrollment
- show the mission context in the enrollment form and clear any previous session data
- update each mission page so the “Inscribirme” link clears the session before rendering enrollment without overwriting the student slug

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ca07e96ba88331b40969c7402d4cf1