### PR TITLE
Fix mission routes to serve HTML files from root

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -536,8 +536,26 @@ def serve_index():
 
 
 @app.route('/m/<path:filename>')
-def serve_mission_page(filename):
-    return _serve_frontend_file(os.path.join('m', filename))
+@app.route('/<mission_id>.html')
+def serve_mission_page(filename=None, mission_id=None):
+    if mission_id is not None:
+        target_filename = f'{mission_id}.html'
+    else:
+        target_filename = filename or ''
+
+    normalized = os.path.normpath(target_filename).lstrip(os.sep)
+    if not normalized:
+        abort(404)
+
+    base_name = os.path.basename(normalized)
+    if normalized != base_name:
+        abort(404)
+
+    base_lower = base_name.lower()
+    if not base_lower.startswith('m') or not base_lower.endswith('.html'):
+        abort(404)
+
+    return _serve_frontend_file(base_name)
 
 
 @app.route('/assets/<path:filename>')


### PR DESCRIPTION
## Summary
- add mission route pattern that accepts `/m1.html` style requests and reuse the old handler for backward compatibility
- validate mission filenames start with `m` and point `_serve_frontend_file` at the frontend root instead of a non-existent `/m/` subdirectory

## Testing
- python - <<'PY'
import werkzeug
if not hasattr(werkzeug, '__version__'):
    werkzeug.__version__ = '0'

from backend import app as app_module

app_module._DB_INITIALIZED = True
client = app_module.app.test_client()

for path in ['m1.html', 'm2.html', 'm6v.html']:
    response = client.get(f'/{path}')
    print(path, response.status_code, len(response.data))

response_dashboard = client.get('/')
print('index.html status', response_dashboard.status_code)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ca0bb2e16483318b0800fbb2633cb4