### PR TITLE
Handle optional backend dependencies for tests

### DIFF
--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -6,7 +6,26 @@ from dataclasses import dataclass
 from typing import Dict
 from urllib.parse import quote
 
-import requests
+try:  # pragma: no cover - optional dependency
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    class _MissingRequestsException(Exception):
+        """Raised when the optional 'requests' dependency is unavailable."""
+
+    class _MissingRequestsSession:
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError(
+                "El cliente de GitHub requiere la dependencia opcional 'requests'. "
+                "Instálala para habilitar las descargas remotas."
+            )
+
+    class _MissingRequestsModule:
+        RequestException = _MissingRequestsException
+
+        def Session(self, *args, **kwargs):  # type: ignore[override]
+            return _MissingRequestsSession(*args, **kwargs)
+
+    requests = _MissingRequestsModule()  # type: ignore[assignment]
 
 
 class GitHubConfigurationError(RuntimeError):

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -7,7 +7,34 @@ import textwrap
 from dataclasses import dataclass
 from typing import Iterable, List, Sequence
 
-from openai import APIConnectionError, APIError, APITimeoutError, OpenAI, RateLimitError
+try:  # pragma: no cover - optional dependency
+    from openai import APIConnectionError, APIError, APITimeoutError, OpenAI, RateLimitError  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    class _MissingOpenAIError(Exception):
+        """Raised when the optional 'openai' package is unavailable."""
+
+    class _MissingOpenAIModule:
+        APIConnectionError = _MissingOpenAIError
+        APIError = _MissingOpenAIError
+        APITimeoutError = _MissingOpenAIError
+        RateLimitError = _MissingOpenAIError
+
+        class _Client:
+            def __init__(self, *args, **kwargs) -> None:
+                raise RuntimeError(
+                    "La evaluación con modelos de lenguaje requiere la dependencia opcional 'openai'. "
+                    "Instálala para habilitar esta funcionalidad."
+                )
+
+        def OpenAI(self, *args, **kwargs):  # type: ignore[override]
+            return self._Client(*args, **kwargs)
+
+    _missing_openai = _MissingOpenAIModule()
+    APIConnectionError = _missing_openai.APIConnectionError
+    APIError = _missing_openai.APIError
+    APITimeoutError = _missing_openai.APITimeoutError
+    OpenAI = _missing_openai.OpenAI  # type: ignore[assignment]
+    RateLimitError = _missing_openai.RateLimitError
 
 DEFAULT_OPENAI_MODEL = "gpt-3.5-turbo"
 _MAX_COMPLETION_TOKENS = 300


### PR DESCRIPTION
## Summary
- add guards around optional backend dependencies so importing the app does not fail when optional packages are absent
- delay importing PyMySQL until a MySQL connection is required and provide no-op fallbacks for CORS and GitHub integrations
- add an OpenAI fallback that surfaces a clear runtime error only when the evaluator is used

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf1915aa4833198ab53e27916d624