### PR TITLE
Handle missing requests dependency as configuration error

### DIFF
--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -6,15 +6,20 @@ from dataclasses import dataclass
 from typing import Dict
 from urllib.parse import quote
 
+
+class GitHubConfigurationError(RuntimeError):
+    """Raised when GitHub integration is misconfigured."""
+
+
 try:  # pragma: no cover - optional dependency
     import requests  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
-    class _MissingRequestsException(Exception):
+    class _MissingRequestsException(GitHubConfigurationError):
         """Raised when the optional 'requests' dependency is unavailable."""
 
     class _MissingRequestsSession:
         def __init__(self, *args, **kwargs) -> None:
-            raise RuntimeError(
+            raise _MissingRequestsException(
                 "El cliente de GitHub requiere la dependencia opcional 'requests'. "
                 "Instálala para habilitar las descargas remotas."
             )
@@ -26,10 +31,6 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
             return _MissingRequestsSession(*args, **kwargs)
 
     requests = _MissingRequestsModule()  # type: ignore[assignment]
-
-
-class GitHubConfigurationError(RuntimeError):
-    """Raised when GitHub integration is misconfigured."""
 
 
 class GitHubDownloadError(RuntimeError):

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+import backend.github_client as github_client
+
+
+class _SessionFailure:
+    def __init__(self, *args, **kwargs):
+        raise github_client.GitHubConfigurationError("session unavailable")
+
+
+def test_github_client_session_failure_surface(monkeypatch):
+    monkeypatch.setattr(github_client.requests, "Session", _SessionFailure)
+    with pytest.raises(github_client.GitHubConfigurationError) as exc:
+        github_client.GitHubClient(token="token")
+    assert "session unavailable" in str(exc.value)
+
+
+def test_github_client_from_env_session_failure(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "token-env")
+    monkeypatch.setenv("GITHUB_API_URL", "https://example.invalid")
+    monkeypatch.setenv("GITHUB_TIMEOUT", "5")
+    monkeypatch.setattr(github_client.requests, "Session", _SessionFailure)
+    with pytest.raises(github_client.GitHubConfigurationError):
+        github_client.GitHubClient.from_env()

--- a/backend/tests/test_verify_mission_config_errors.py
+++ b/backend/tests/test_verify_mission_config_errors.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend import app as backend_app
+from backend.github_client import GitHubConfigurationError
+
+
+class _DummyCursor:
+    def __init__(self, role: str = "") -> None:
+        self._role = role
+
+    def __enter__(self) -> "_DummyCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: Any) -> None:
+        return None
+
+    def fetchone(self) -> dict:
+        return {"role": self._role}
+
+    def fetchall(self) -> list:
+        return []
+
+
+class _DummyConnection:
+    def __init__(self, role: str = "") -> None:
+        self._role = role
+
+    def __enter__(self) -> "_DummyConnection":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def cursor(self) -> _DummyCursor:
+        return _DummyCursor(self._role)
+
+
+@pytest.fixture(autouse=True)
+def _configure_app(monkeypatch):
+    backend_app.app.config["TESTING"] = True
+    monkeypatch.setattr(backend_app, "init_db", lambda: None)
+    monkeypatch.setattr(backend_app, "get_db_connection", lambda: _DummyConnection("ventas"))
+    monkeypatch.setattr(backend_app, "validate_session", lambda token, slug=None: True)
+
+
+def _patch_contract(monkeypatch, verification_type: str) -> None:
+    contract = {"verification_type": verification_type}
+    monkeypatch.setattr(backend_app, "load_contracts", lambda: {"mission": contract})
+
+
+def _patch_client_failure(monkeypatch, message: str) -> None:
+    def _raise(cls):
+        raise GitHubConfigurationError(message)
+
+    monkeypatch.setattr(backend_app.GitHubClient, "from_env", classmethod(_raise))
+
+
+@pytest.mark.parametrize("verification_type", ["evidence", "script_output"])
+def test_verify_mission_returns_configuration_error(monkeypatch, verification_type):
+    _patch_contract(monkeypatch, verification_type)
+    _patch_client_failure(monkeypatch, "sin requests")
+    client = backend_app.app.test_client()
+    response = client.post(
+        "/api/verify_mission",
+        json={"slug": "student", "mission_id": "mission"},
+        headers={"Authorization": "Bearer token"},
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload == {"verified": False, "feedback": ["sin requests"]}


### PR DESCRIPTION
## Summary
- update the optional requests shim so a missing dependency raises `GitHubConfigurationError`
- add regression tests verifying the GitHub client surfaces shim failures
- exercise `/api/verify_mission` evidence and script flows to confirm configuration errors return the expected response

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caffc5431c8331837054c1d46e417a