### PR TITLE
Normalize branch overrides in repository selection

### DIFF
--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -208,8 +208,13 @@ def select_repository_for_contract(
             )
 
     branch_env = source.get("branch_env")
-    branch_override = os.environ.get(branch_env, "") if branch_env else ""
-    branch = branch_override or source.get("branch") or source.get("default_branch") or info.default_branch
+    branch_override = _normalize_branch(os.environ.get(branch_env)) if branch_env else None
+    branch = (
+        branch_override
+        or _normalize_branch(source.get("branch"))
+        or _normalize_branch(source.get("default_branch"))
+        or info.default_branch
+    )
 
     base_path_template = source.get("base_path", "") or ""
     try:
@@ -221,6 +226,13 @@ def select_repository_for_contract(
     base_path = (formatted_base or "").strip("/")
 
     return RepositorySelection(info=info, branch=branch or info.default_branch, base_path=base_path)
+
+
+def _normalize_branch(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
 
 
 class RepositoryFileAccessor:

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -23,3 +23,23 @@ def test_github_client_from_env_session_failure(monkeypatch):
     monkeypatch.setattr(github_client.requests, "Session", _SessionFailure)
     with pytest.raises(github_client.GitHubConfigurationError):
         github_client.GitHubClient.from_env()
+
+
+def test_select_repository_for_contract_strips_branch_overrides(monkeypatch):
+    repositories = {
+        "ventas": github_client.RepositoryInfo(
+            key="ventas", repository="org/repo", default_branch="main"
+        )
+    }
+    monkeypatch.setenv("CUSTOM_BRANCH", "   ")
+    selection = github_client.select_repository_for_contract(
+        {
+            "repository": "ventas",
+            "branch_env": "CUSTOM_BRANCH",
+            "branch": " \n ",
+            "default_branch": "\t",
+        },
+        slug="student-x",
+        repositories=repositories,
+    )
+    assert selection.branch == "main"


### PR DESCRIPTION
## Summary
- normalize branch override inputs when selecting the repository branch for a contract
- add a regression test covering whitespace-only overrides to ensure the default branch is used

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cb0f6a7b5c83319caecef9c077aca8