### PR TITLE
Fix m1 workspace path contract

### DIFF
--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -15,7 +15,7 @@
       {
         "type": "file_contains",
         "path": "docs/m1_workspace_ok.txt",
-        "content": "workspace: C:\\\\\MinecraftShop\\\\minecraft_shop_project",
+        "content": "workspace: C\\MinecraftShop\\minecraft_shop_project",
         "feedback_fail": "El archivo 'm1_workspace_ok.txt' no contiene la línea exacta requerida."
       },
       {


### PR DESCRIPTION
## Summary
- correct the m1 contract to expect the proper workspace path string for Windows setups

## Testing
- python -m json.tool backend/missions_contracts.json
- curl -s -w "\nHTTP_STATUS:%{http_code}\n" -X POST http://127.0.0.1:8080/api/verify_mission -H "Content-Type: application/json" -H "Authorization: Bearer testtoken123" -d '{"slug":"test-student","mission_id":"m1"}'


------
https://chatgpt.com/codex/tasks/task_e_68cb1396345483318a7ed003b8754485