### PR TITLE
Guard mission pages behind status helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Este proyecto implementa un portal web de entrenamiento basado en misiones. Los estudiantes se matriculan, avanzan por las misiones y deben cumplir contratos de entrega que se verifican de manera automática. Está dividido en frontend (HTML, CSS y JavaScript), backend (Python Flask) y un archivo de contratos en YAML. Puedes empaquetar y desplegar la aplicación en Windows IIS mediante el script `install_all.ps1`.
 
+## Flujo de acceso a misiones en el frontend
+
+La lógica que determina qué misiones están desbloqueadas vive en `frontend/assets/js/main.js` dentro del helper `ensureMissionUnlocked(missionId)`. Este helper lee el `slug` y `token` guardados, consulta `/api/status` y reconstruye el mapa de progreso según el rol del estudiante. Si la sesión no existe, expiró o falta completar la misión previa, limpia el almacenamiento local y devuelve una instrucción para redirigir de vuelta al portal o mostrar un aviso.
+
+Cada página de misión (por ejemplo `frontend/m3.html`) debe ocultar su `<main>` inicial usando el atributo `hidden` y, en `DOMContentLoaded`, llamar a `ensureMissionUnlocked`. Si la respuesta indica que el acceso es válido, la página quita el `hidden`, enlaza el botón de verificación y deja visible el contenido. Cuando el helper responde con una redirección se envía al estudiante a `index.html`; si se trata de progreso faltante, se reemplaza el cuerpo con un mensaje que invita a completar la misión anterior. Sigue este patrón para cualquier misión nueva para mantener una experiencia homogénea.
+
 ## Configuración de base de datos
 
 El servicio backend persiste estudiantes y misiones completadas en una base de datos MySQL (por ejemplo, Cloud SQL for MySQL). Antes de iniciar el servidor debes definir las siguientes variables de entorno:

--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -45,7 +45,7 @@
       <h1 class="portal-header__heading">M1 — La Puerta de la Base (VS Code + Python)</h1>
     </div>
   </header>
-  <main>
+  <main hidden>
     <section class="mission">
       <h2>Historia</h2>
       <p>La Base Central se ilumina cuando llegan. En el centro, una mesa con dos piezas clave: una libreta brillante y un cristal con forma de serpiente.</p>
@@ -133,13 +133,49 @@
   </main>
   <script src="assets/js/main.js"></script>
   <script>
-    // Comprueba acceso y configura el botón de verificación
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
+      const missionId = 'm1';
+      const mainContent = document.querySelector('main');
       const resultDiv = document.getElementById('verifyResult');
-      const btn = document.getElementById('verifyBtn');
-      btn.addEventListener('click', () => {
-        verifyMission('m1', resultDiv);
-      });
+      const verifyBtn = document.getElementById('verifyBtn');
+
+      const showMission = () => {
+        if (mainContent) {
+          mainContent.removeAttribute('hidden');
+        }
+        if (verifyBtn && resultDiv) {
+          verifyBtn.addEventListener('click', () => {
+            verifyMission(missionId, resultDiv);
+          });
+        }
+      };
+
+      const showMessage = (message) => {
+        document.body.innerHTML = `
+          <main class="mission-locked">
+            <section class="status-error">
+              <h2>Acceso restringido</h2>
+              <p>${message}</p>
+              <p><a href="index.html">Volver al portal</a></p>
+            </section>
+          </main>
+        `;
+      };
+
+      try {
+        const access = await ensureMissionUnlocked(missionId);
+        if (access.allowed) {
+          showMission();
+          return;
+        }
+        if (access.action === 'redirect' && access.redirectTo) {
+          window.location.href = access.redirectTo;
+          return;
+        }
+        showMessage(access.message || 'Debes abrir esta misión desde el portal principal.');
+      } catch (err) {
+        showMessage('No pudimos validar tu acceso. Abre la misión desde el portal principal.');
+      }
     });
   </script>
 </body>

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -45,7 +45,7 @@
       <h1 class="portal-header__heading">M2 — Despierta a tu Aliado (venv)</h1>
     </div>
   </header>
-  <main>
+  <main hidden>
     <section class="mission">
       <h2>Historia</h2>
       <p>En una sala contigua, Byte abre un armario con frascos parecidos: “A simple vista, todos son Python, pero cada proyecto necesita su propio espacio para no mezclar recetas”. Señala un círculo protector: “Ese campo es tu .venv. Dentro de él, pip instala ingredientes exactos sin contaminar otras recetas.</p>
@@ -133,11 +133,51 @@
   </main>
   <script src="assets/js/main.js"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
+      const missionId = 'm2';
+      const mainContent = document.querySelector('main');
       const resultDiv = document.getElementById('verifyResult');
-      document.getElementById('verifyBtn').addEventListener('click', () => {
-        verifyMission('m2', resultDiv);
-      });
+      const verifyBtn = document.getElementById('verifyBtn');
+
+      const showMission = () => {
+        if (mainContent) {
+          mainContent.removeAttribute('hidden');
+        }
+        if (verifyBtn && resultDiv) {
+          verifyBtn.addEventListener('click', () => {
+            verifyMission(missionId, resultDiv);
+          });
+        }
+      };
+
+      const showMessage = (message) => {
+        document.body.innerHTML = `
+          <main class="mission-locked">
+            <section class="status-error">
+              <h2>Acceso restringido</h2>
+              <p>${message}</p>
+              <p><a href="index.html">Volver al portal</a></p>
+            </section>
+          </main>
+        `;
+      };
+
+      try {
+        const access = await ensureMissionUnlocked(missionId);
+        if (access.allowed) {
+          showMission();
+          return;
+        }
+        if (access.action === 'redirect' && access.redirectTo) {
+          window.location.href = access.redirectTo;
+          return;
+        }
+        showMessage(
+          access.message || 'Debes completar la misión anterior antes de continuar con esta etapa.'
+        );
+      } catch (err) {
+        showMessage('No pudimos validar tu acceso. Abre la misión desde el portal principal.');
+      }
     });
   </script>
 </body>

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -45,7 +45,7 @@
       <h1 class="portal-header__heading">M3 — Cofres CSV y DataFrames (pandas)</h1>
     </div>
   </header>
-  <main>
+  <main hidden>
     <section class="mission">
       <h2>Historia</h2>
       <p>El pasillo conduce a una bodega con cofres etiquetados: orders, products, customers. “Estos cofres son CSV”, explica Byte. “Parecen listas, pero esconden tablas. Para leerlos sin perdernos, usaremos una lupa especial: pandas. Con pandas, los cofres se transforman en DataFrames.”</p>
@@ -130,11 +130,51 @@
   </main>
   <script src="assets/js/main.js"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
+      const missionId = 'm3';
+      const mainContent = document.querySelector('main');
       const resultDiv = document.getElementById('verifyResult');
-      document.getElementById('verifyBtn').addEventListener('click', () => {
-        verifyMission('m3', resultDiv);
-      });
+      const verifyBtn = document.getElementById('verifyBtn');
+
+      const showMission = () => {
+        if (mainContent) {
+          mainContent.removeAttribute('hidden');
+        }
+        if (verifyBtn && resultDiv) {
+          verifyBtn.addEventListener('click', () => {
+            verifyMission(missionId, resultDiv);
+          });
+        }
+      };
+
+      const showMessage = (message) => {
+        document.body.innerHTML = `
+          <main class="mission-locked">
+            <section class="status-error">
+              <h2>Acceso restringido</h2>
+              <p>${message}</p>
+              <p><a href="index.html">Volver al portal</a></p>
+            </section>
+          </main>
+        `;
+      };
+
+      try {
+        const access = await ensureMissionUnlocked(missionId);
+        if (access.allowed) {
+          showMission();
+          return;
+        }
+        if (access.action === 'redirect' && access.redirectTo) {
+          window.location.href = access.redirectTo;
+          return;
+        }
+        showMessage(
+          access.message || 'Debes completar la misión anterior antes de continuar con esta etapa.'
+        );
+      } catch (err) {
+        showMessage('No pudimos validar tu acceso. Abre la misión desde el portal principal.');
+      }
     });
   </script>
 </body>

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -45,7 +45,7 @@
       <h1 class="portal-header__heading">M4 — Bronze: Ingesta y Copia fiel</h1>
     </div>
   </header>
-  <main>
+  <main hidden>
     <section class="mission">
       <h2>Historia</h2>
       <p>El pasillo conduce a la Cámara Bronze, un cuarto frío con estantes alineados. “Aquí no se toca nada”, advierte Byte. “Bronze es la foto exacta de lo que llegó. Si cambias una mayúscula, ya no es la misma foto.”</p>
@@ -129,11 +129,51 @@
   </main>
   <script src="assets/js/main.js"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
+      const missionId = 'm4';
+      const mainContent = document.querySelector('main');
       const resultDiv = document.getElementById('verifyResult');
-      document.getElementById('verifyBtn').addEventListener('click', () => {
-        verifyMission('m4', resultDiv);
-      });
+      const verifyBtn = document.getElementById('verifyBtn');
+
+      const showMission = () => {
+        if (mainContent) {
+          mainContent.removeAttribute('hidden');
+        }
+        if (verifyBtn && resultDiv) {
+          verifyBtn.addEventListener('click', () => {
+            verifyMission(missionId, resultDiv);
+          });
+        }
+      };
+
+      const showMessage = (message) => {
+        document.body.innerHTML = `
+          <main class="mission-locked">
+            <section class="status-error">
+              <h2>Acceso restringido</h2>
+              <p>${message}</p>
+              <p><a href="index.html">Volver al portal</a></p>
+            </section>
+          </main>
+        `;
+      };
+
+      try {
+        const access = await ensureMissionUnlocked(missionId);
+        if (access.allowed) {
+          showMission();
+          return;
+        }
+        if (access.action === 'redirect' && access.redirectTo) {
+          window.location.href = access.redirectTo;
+          return;
+        }
+        showMessage(
+          access.message || 'Debes completar la misión anterior antes de continuar con esta etapa.'
+        );
+      } catch (err) {
+        showMessage('No pudimos validar tu acceso. Abre la misión desde el portal principal.');
+      }
     });
   </script>
 </body>

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -45,7 +45,7 @@
       <h1 class="portal-header__heading">M5 — Silver: Limpieza y Tipos</h1>
     </div>
   </header>
-  <main>
+  <main hidden>
     <section class="mission">
       <h2>Historia</h2>
       <p>La siguiente puerta se abre a un taller plateado. “Silver es donde quitamos lo que estorba”, dice Byte. “Recortamos espacios, corregimos tipos y eliminamos duplicados. No adornamos los datos: los dejamos confiables para unir en Gold.”</p>
@@ -131,11 +131,51 @@
   </main>
   <script src="assets/js/main.js"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
+      const missionId = 'm5';
+      const mainContent = document.querySelector('main');
       const resultDiv = document.getElementById('verifyResult');
-      document.getElementById('verifyBtn').addEventListener('click', () => {
-        verifyMission('m5', resultDiv);
-      });
+      const verifyBtn = document.getElementById('verifyBtn');
+
+      const showMission = () => {
+        if (mainContent) {
+          mainContent.removeAttribute('hidden');
+        }
+        if (verifyBtn && resultDiv) {
+          verifyBtn.addEventListener('click', () => {
+            verifyMission(missionId, resultDiv);
+          });
+        }
+      };
+
+      const showMessage = (message) => {
+        document.body.innerHTML = `
+          <main class="mission-locked">
+            <section class="status-error">
+              <h2>Acceso restringido</h2>
+              <p>${message}</p>
+              <p><a href="index.html">Volver al portal</a></p>
+            </section>
+          </main>
+        `;
+      };
+
+      try {
+        const access = await ensureMissionUnlocked(missionId);
+        if (access.allowed) {
+          showMission();
+          return;
+        }
+        if (access.action === 'redirect' && access.redirectTo) {
+          window.location.href = access.redirectTo;
+          return;
+        }
+        showMessage(
+          access.message || 'Debes completar la misión anterior antes de continuar con esta etapa.'
+        );
+      } catch (err) {
+        showMessage('No pudimos validar tu acceso. Abre la misión desde el portal principal.');
+      }
     });
   </script>
 </body>

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -45,7 +45,7 @@
       <h1 class="portal-header__heading">M6 — Gold Operaciones: Une y mide</h1>
     </div>
   </header>
-  <main>
+  <main hidden>
     <section class="mission">
       <h2>Historia</h2>
       <p>En la Estación Logística, tableros muestran rutas y paquetes. “Para cumplir promesas”, dice Byte, “necesitamos visibilidad: unir pedidos con clientes para saber en qué ciudad está cada envío.”</p>
@@ -125,11 +125,51 @@
   </main>
   <script src="assets/js/main.js"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
+      const missionId = 'm6o';
+      const mainContent = document.querySelector('main');
       const resultDiv = document.getElementById('verifyResult');
-      document.getElementById('verifyBtn').addEventListener('click', () => {
-        verifyMission('m6o', resultDiv);
-      });
+      const verifyBtn = document.getElementById('verifyBtn');
+
+      const showMission = () => {
+        if (mainContent) {
+          mainContent.removeAttribute('hidden');
+        }
+        if (verifyBtn && resultDiv) {
+          verifyBtn.addEventListener('click', () => {
+            verifyMission(missionId, resultDiv);
+          });
+        }
+      };
+
+      const showMessage = (message) => {
+        document.body.innerHTML = `
+          <main class="mission-locked">
+            <section class="status-error">
+              <h2>Acceso restringido</h2>
+              <p>${message}</p>
+              <p><a href="index.html">Volver al portal</a></p>
+            </section>
+          </main>
+        `;
+      };
+
+      try {
+        const access = await ensureMissionUnlocked(missionId);
+        if (access.allowed) {
+          showMission();
+          return;
+        }
+        if (access.action === 'redirect' && access.redirectTo) {
+          window.location.href = access.redirectTo;
+          return;
+        }
+        showMessage(
+          access.message || 'Debes completar la misión anterior antes de continuar con esta etapa.'
+        );
+      } catch (err) {
+        showMessage('No pudimos validar tu acceso. Abre la misión desde el portal principal.');
+      }
     });
   </script>
 </body>

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -45,7 +45,7 @@
       <h1 class="portal-header__heading">M6 — Gold (VENTAS): Une y mide</h1>
     </div>
   </header>
-  <main>
+  <main hidden>
     <section class="mission">
       <h2>Historia</h2>
       <p>Llegan al Salón del Mercado. Tres caminos desembocan en una mesa de unión: pedidos, productos y clientes. “El consejo no quiere anécdotas; quiere medidas”, dice Byte. “En Gold (Ventas) unirás con joins left para no perder pedidos. Crearás la runa clave: ingreso = quantity × price. Luego generarás ventas por día, top productos y ventas por ciudad. Si un nombre de producto o una ciudad aparece vacío, la historia está incompleta: revisa claves y tipo de join.”</p>
@@ -125,11 +125,51 @@
   </main>
   <script src="assets/js/main.js"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
+      const missionId = 'm6v';
+      const mainContent = document.querySelector('main');
       const resultDiv = document.getElementById('verifyResult');
-      document.getElementById('verifyBtn').addEventListener('click', () => {
-        verifyMission('m6v', resultDiv);
-      });
+      const verifyBtn = document.getElementById('verifyBtn');
+
+      const showMission = () => {
+        if (mainContent) {
+          mainContent.removeAttribute('hidden');
+        }
+        if (verifyBtn && resultDiv) {
+          verifyBtn.addEventListener('click', () => {
+            verifyMission(missionId, resultDiv);
+          });
+        }
+      };
+
+      const showMessage = (message) => {
+        document.body.innerHTML = `
+          <main class="mission-locked">
+            <section class="status-error">
+              <h2>Acceso restringido</h2>
+              <p>${message}</p>
+              <p><a href="index.html">Volver al portal</a></p>
+            </section>
+          </main>
+        `;
+      };
+
+      try {
+        const access = await ensureMissionUnlocked(missionId);
+        if (access.allowed) {
+          showMission();
+          return;
+        }
+        if (access.action === 'redirect' && access.redirectTo) {
+          window.location.href = access.redirectTo;
+          return;
+        }
+        showMessage(
+          access.message || 'Debes completar la misión anterior antes de continuar con esta etapa.'
+        );
+      } catch (err) {
+        showMessage('No pudimos validar tu acceso. Abre la misión desde el portal principal.');
+      }
     });
   </script>
 </body>

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -45,7 +45,7 @@
       <h1 class="portal-header__heading">M7 — Consejo de la Tienda (Power BI)</h1>
     </div>
   </header>
-  <main>
+  <main hidden>
     <section class="mission">
       <h2>Historia</h2>
       <p>La última sala es un auditorio. El Consejo de la Tienda aguarda. “Llegaron hasta aquí porque supieron preparar su taller, leer cofres, copiar con cuidado, limpiar con criterio y medir con precisión”, sonríe Byte.</p>
@@ -128,11 +128,51 @@
   </main>
   <script src="assets/js/main.js"></script>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
+      const missionId = 'm7';
+      const mainContent = document.querySelector('main');
       const resultDiv = document.getElementById('verifyResult');
-      document.getElementById('verifyBtn').addEventListener('click', () => {
-        verifyMission('m7', resultDiv);
-      });
+      const verifyBtn = document.getElementById('verifyBtn');
+
+      const showMission = () => {
+        if (mainContent) {
+          mainContent.removeAttribute('hidden');
+        }
+        if (verifyBtn && resultDiv) {
+          verifyBtn.addEventListener('click', () => {
+            verifyMission(missionId, resultDiv);
+          });
+        }
+      };
+
+      const showMessage = (message) => {
+        document.body.innerHTML = `
+          <main class="mission-locked">
+            <section class="status-error">
+              <h2>Acceso restringido</h2>
+              <p>${message}</p>
+              <p><a href="index.html">Volver al portal</a></p>
+            </section>
+          </main>
+        `;
+      };
+
+      try {
+        const access = await ensureMissionUnlocked(missionId);
+        if (access.allowed) {
+          showMission();
+          return;
+        }
+        if (access.action === 'redirect' && access.redirectTo) {
+          window.location.href = access.redirectTo;
+          return;
+        }
+        showMessage(
+          access.message || 'Debes completar la misión anterior antes de continuar con esta etapa.'
+        );
+      } catch (err) {
+        showMessage('No pudimos validar tu acceso. Abre la misión desde el portal principal.');
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- extract mission unlocking logic into reusable helpers shared by the dashboard and mission pages
- gate each mission HTML with ensureMissionUnlocked so content only renders for unlocked students
- document the new access flow for future mission pages in the README

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cb2c47c22c83318cbe1a0d52ee6280