### PR TITLE
Add admin flag support across backend and frontend

### DIFF
--- a/backend/migrations/004_add_is_admin_flag.sql
+++ b/backend/migrations/004_add_is_admin_flag.sql
@@ -1,0 +1,8 @@
+-- Adds an explicit admin flag to student records.
+ALTER TABLE students
+    ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT 0;
+
+-- Promote the default admin account.
+UPDATE students
+SET is_admin = 1
+WHERE slug = 'dalarcon80';

--- a/backend/tests/test_missions_api.py
+++ b/backend/tests/test_missions_api.py
@@ -36,10 +36,10 @@ def _prepare_admin(slug: str = "admin-test") -> str:
             cur.execute("DELETE FROM students")
             cur.execute(
                 """
-                INSERT INTO students (slug, name, role, email, password_hash)
-                VALUES (%s, %s, %s, %s, %s)
+                INSERT INTO students (slug, name, role, email, password_hash, is_admin)
+                VALUES (%s, %s, %s, %s, %s, %s)
                 """,
-                (slug, "Admin", "admin", "admin@example.com", ""),
+                (slug, "Admin", "admin", "admin@example.com", "", 1),
             )
     return backend_app.create_session(slug)
 
@@ -127,8 +127,8 @@ def test_admin_mission_requires_admin(sqlite_backend):
         with conn.cursor() as cur:
             cur.execute("DELETE FROM students")
             cur.execute(
-                "INSERT INTO students (slug, role, email) VALUES (%s, %s, %s)",
-                ("student", "learner", "student@example.com"),
+                "INSERT INTO students (slug, role, email, is_admin) VALUES (%s, %s, %s, %s)",
+                ("student", "admin", "student@example.com", 0),
             )
     token = backend_app.create_session("student")
     client = backend_app.app.test_client()

--- a/backend/tests/test_sqlite_backend.py
+++ b/backend/tests/test_sqlite_backend.py
@@ -67,6 +67,7 @@ class SQLiteBackendFlowTests(unittest.TestCase):
         self.assertTrue(login_data["authenticated"])
         self.assertTrue(login_data["token"])
         self.assertEqual(login_data["student"]["email"], payload["email"])
+        self.assertFalse(login_data["student"]["is_admin"])
         self.assertEqual(login_data["completed"], [])
 
         status_response = self.client.get(
@@ -76,15 +77,17 @@ class SQLiteBackendFlowTests(unittest.TestCase):
         status_data = status_response.get_json()
         self.assertEqual(status_data["student"]["slug"], payload["slug"])
         self.assertEqual(status_data["student"]["name"], payload["name"])
+        self.assertFalse(status_data["student"]["is_admin"])
         self.assertEqual(status_data["completed"], [])
 
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
             cur.execute(
-                "SELECT slug, name, email FROM students WHERE slug = ?",
+                "SELECT slug, name, email, is_admin FROM students WHERE slug = ?",
                 (payload["slug"],),
             )
             row = cur.fetchone()
             self.assertIsNotNone(row)
             self.assertEqual(dict(row)["email"], payload["email"])
+            self.assertEqual(dict(row)["is_admin"], 0)

--- a/backend/tests/test_verify_mission_config_errors.py
+++ b/backend/tests/test_verify_mission_config_errors.py
@@ -49,7 +49,11 @@ def _configure_app(monkeypatch):
     monkeypatch.setattr(
         backend_app, "_fetch_missions_from_db", lambda mission_id=None: []
     )
-    monkeypatch.setattr(backend_app, "validate_session", lambda token, slug=None: True)
+    monkeypatch.setattr(
+        backend_app,
+        "validate_session",
+        lambda token, slug=None, require_admin=False: True,
+    )
     import werkzeug
 
     if not hasattr(werkzeug, "__version__"):


### PR DESCRIPTION
## Summary
- add an explicit `is_admin` flag to the students schema and migrations for both database engines
- enforce the admin flag in session validation and mission admin endpoints while seeding the default admin user
- expose the flag through login/status responses, update tests, and persist it in the frontend session storage

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cb43c56fd483319cfd689f83f1d918