### PR TITLE
Pin Werkzeug dependency to compatible 2.x range

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.3.2
+Werkzeug>=2.3.0,<3.0.0
 Flask-Cors==3.0.10
 PyYAML==6.0
 gunicorn==20.1.0


### PR DESCRIPTION
## Summary
- add an explicit Werkzeug version constraint compatible with Flask 2.3.2

## Testing
- pytest backend/tests/test_missions_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cb4ce7e3388331b519bcb724f079b9