### PR TITLE
Redirect to landing when cached content missing

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -295,11 +295,18 @@ function getContentContainer() {
 
 function renderLandingContent() {
   cacheLandingContent();
-  const content = getContentContainer();
   if (!landingContentHTML) {
-    content.innerHTML = '';
+    if (typeof window !== 'undefined' && window.location) {
+      const target = 'index.html';
+      if (typeof window.location.assign === 'function') {
+        window.location.assign(target);
+      } else {
+        window.location.href = target;
+      }
+    }
     return;
   }
+  const content = getContentContainer();
   content.innerHTML = landingContentHTML;
 }
 


### PR DESCRIPTION
## Summary
- ensure `renderLandingContent` redirects back to `index.html` when no cached landing content is available
- keep existing logic that restores cached landing markup when present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb5f31ea5c8331989957e989118fa7