### PR TITLE
Display mission slug and descriptive name on dashboard cards

### DIFF
--- a/frontend/assets/css/style-dark.css
+++ b/frontend/assets/css/style-dark.css
@@ -375,19 +375,49 @@ form button:hover {
   box-shadow: var(--card-shadow-hover);
 }
 
-.mission-card a {
+.mission-card__link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
   text-decoration: none;
-  color: var(--accent);
+  color: inherit;
   font-weight: 600;
 }
 
-.mission-card a:hover {
+.mission-card__link:hover,
+.mission-card__link:focus-visible {
+  text-decoration: none;
+  outline: none;
+}
+
+.mission-card__slug {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.mission-card__name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.45;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.mission-card__link:hover .mission-card__slug,
+.mission-card__link:focus-visible .mission-card__slug,
+.mission-card__link:hover .mission-card__name,
+.mission-card__link:focus-visible .mission-card__name {
   color: var(--accent-hover);
 }
 
 .mission-card .status {
   font-weight: 600;
   color: var(--muted);
+  align-self: flex-start;
 }
 
 .mission-card.locked {
@@ -397,12 +427,14 @@ form button:hover {
   box-shadow: none;
 }
 
-.mission-card.locked a {
+.mission-card.locked .mission-card__link {
   color: var(--muted);
-  pointer-events: none;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
+.mission-card.locked .mission-card__slug,
+.mission-card.locked .mission-card__name,
 .mission-card.locked .status {
   color: var(--muted);
 }

--- a/frontend/assets/css/style.css
+++ b/frontend/assets/css/style.css
@@ -166,19 +166,49 @@ form button:hover {
   box-shadow: var(--card-shadow-hover);
 }
 
-.mission-card a {
+.mission-card__link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
   text-decoration: none;
-  color: var(--accent);
+  color: inherit;
   font-weight: 600;
 }
 
-.mission-card a:hover {
+.mission-card__link:hover,
+.mission-card__link:focus-visible {
+  text-decoration: none;
+  outline: none;
+}
+
+.mission-card__slug {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.mission-card__name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.45;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.mission-card__link:hover .mission-card__slug,
+.mission-card__link:focus-visible .mission-card__slug,
+.mission-card__link:hover .mission-card__name,
+.mission-card__link:focus-visible .mission-card__name {
   color: var(--accent-hover);
 }
 
 .mission-card .status {
   font-weight: 600;
   color: var(--muted);
+  align-self: flex-start;
 }
 
 .mission-card.locked {
@@ -188,12 +218,14 @@ form button:hover {
   box-shadow: none;
 }
 
-.mission-card.locked a {
+.mission-card.locked .mission-card__link {
   color: var(--muted);
-  pointer-events: none;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
+.mission-card.locked .mission-card__slug,
+.mission-card.locked .mission-card__name,
 .mission-card.locked .status {
   color: var(--muted);
 }

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -406,14 +406,14 @@ function renderDashboard(student, completed) {
   const content = $('#content');
   // Definición de las misiones y sus roles permitidos
   const MISSIONS = [
-    { id: 'm1', title: 'M1 — La Puerta de la Base', roles: ['Ventas', 'Operaciones'] },
-    { id: 'm2', title: 'M2 — Despierta a tu Aliado', roles: ['Ventas', 'Operaciones'] },
-    { id: 'm3', title: 'M3 — Cofres CSV y DataFrames', roles: ['Ventas', 'Operaciones'] },
-    { id: 'm4', title: 'M4 — Bronze: Ingesta y Copia fiel', roles: ['Ventas', 'Operaciones'] },
-    { id: 'm5', title: 'M5 — Silver: Limpieza y Tipos', roles: ['Ventas', 'Operaciones'] },
-    { id: 'm6v', title: 'M6 — Gold (VENTAS): Une y mide', roles: ['Ventas'] },
-    { id: 'm6o', title: 'M6 — Gold (OPERACIONES): Une y mide', roles: ['Operaciones'] },
-    { id: 'm7', title: 'M7 — Consejo de la Tienda', roles: ['Ventas', 'Operaciones'] },
+    { id: 'm1', slug: 'm1', title: 'La Puerta de la Base', roles: ['Ventas', 'Operaciones'] },
+    { id: 'm2', slug: 'm2', title: 'Despierta a tu Aliado', roles: ['Ventas', 'Operaciones'] },
+    { id: 'm3', slug: 'm3', title: 'Cofres CSV y DataFrames', roles: ['Ventas', 'Operaciones'] },
+    { id: 'm4', slug: 'm4', title: 'Bronze: Ingesta y Copia fiel', roles: ['Ventas', 'Operaciones'] },
+    { id: 'm5', slug: 'm5', title: 'Silver: Limpieza y Tipos', roles: ['Ventas', 'Operaciones'] },
+    { id: 'm6v', slug: 'm6v', title: 'Gold (VENTAS): Une y mide', roles: ['Ventas'] },
+    { id: 'm6o', slug: 'm6o', title: 'Gold (OPERACIONES): Une y mide', roles: ['Operaciones'] },
+    { id: 'm7', slug: 'm7', title: 'Consejo de la Tienda', roles: ['Ventas', 'Operaciones'] },
   ];
   // Filtrar misiones según rol
   const missionsForRole = MISSIONS.filter((m) => m.roles.includes(student.role));
@@ -453,10 +453,11 @@ function renderDashboard(student, completed) {
       statusClass = 'locked';
       statusText = 'Bloqueada';
     }
+    const titleMarkup = `<span class="mission-card__slug">${m.slug}</span><span class="mission-card__name">${m.title}</span>`;
     if (isUnlocked) {
-      html += `<li class="mission-card ${statusClass}"><a href="${m.id}.html">${m.title}</a><span class="status">${statusText}</span></li>`;
+      html += `<li class="mission-card ${statusClass}"><a href="${m.id}.html" class="mission-card__link">${titleMarkup}</a><span class="status">${statusText}</span></li>`;
     } else {
-      html += `<li class="mission-card ${statusClass}">${m.title}<span class="status">${statusText}</span></li>`;
+      html += `<li class="mission-card ${statusClass}"><span class="mission-card__link mission-card__link--disabled">${titleMarkup}</span><span class="status">${statusText}</span></li>`;
     }
   });
   html += '</ul>';


### PR DESCRIPTION
## Summary
- split mission metadata so the dashboard can show the slug alongside the descriptive title
- adjust unlocked and locked mission card markup to expose consistent slug and name elements
- style the new mission card slug/name elements for both light and dark themes while preserving the status pill layout

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb6f6e70d88331bd673a1063f4c569