### PR TITLE
Fix legacy enrollment CTA targeting

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -550,10 +550,7 @@ function setupAccessLinks() {
     renderLoginForm();
   });
 
-  const legacyEnrollLinks = document.querySelectorAll('a[href="m1.html"]');
-  legacyEnrollLinks.forEach((link) => {
-    link.href = '#';
-  });
+  const legacyEnrollLinks = document.querySelectorAll('[data-action="legacy-enroll"]');
   attachHandler(legacyEnrollLinks, () => {
     clearSession();
     renderEnrollForm();

--- a/frontend/m1.html
+++ b/frontend/m1.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           data-action="legacy-enroll">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m2.html
+++ b/frontend/m2.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           data-action="legacy-enroll">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m3.html
+++ b/frontend/m3.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           data-action="legacy-enroll">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m4.html
+++ b/frontend/m4.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           data-action="legacy-enroll">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m5.html
+++ b/frontend/m5.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           data-action="legacy-enroll">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m6o.html
+++ b/frontend/m6o.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           data-action="legacy-enroll">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m6v.html
+++ b/frontend/m6v.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           data-action="legacy-enroll">
           Inscribirme
         </a>
       </nav>

--- a/frontend/m7.html
+++ b/frontend/m7.html
@@ -22,7 +22,7 @@
         <a class="portal-header__link" href="/index.html">Inicio</a>
         <a class="portal-header__link"
            href="#"
-           onclick="localStorage.removeItem('student_slug'); renderEnrollForm(); return false;">
+           data-action="legacy-enroll">
           Inscribirme
         </a>
       </nav>


### PR DESCRIPTION
## Summary
- update the access link hook to target a dedicated legacy enrollment data-action
- tag mission detail headers with the new identifier so the legacy CTA still renders the enrollment form
- remove the broad m1.html selector so mission tiles keep their navigation behaviour

## Testing
- Manual verification via Playwright: mission card opens m1.html and legacy CTA opens the enrollment form

------
https://chatgpt.com/codex/tasks/task_e_68cbe7dfeac0833186d9189b48ff59c9