### PR TITLE
Refactor front-end admin module

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ Los administradores autenticados (token válido en el encabezado `Authorization:
 
 El backend reutiliza los helpers `hash_password` y `verify_password` para validar los cambios de contraseña y mantiene la compatibilidad tanto con SQLite como con MySQL. Todos los endpoints devuelven errores `401/403` cuando el token es inválido o pertenece a un usuario sin privilegios administrativos.
 
+## Validación manual del panel administrativo
+
+Sigue estos pasos para comprobar el flujo completo del nuevo módulo web cuando no haya pruebas automatizadas disponibles:
+
+1. Instala las dependencias del backend (`pip install -r backend/requirements.txt`) y arranca el servidor con `FLASK_APP=backend.app flask run` o el comando equivalente a tu entorno.
+2. Abre `frontend/index.html` desde un servidor estático (por ejemplo con `python -m http.server` en la carpeta `frontend/`).
+3. Inicia sesión en el portal con un usuario administrativo existente. Si necesitas uno nuevo, crea primero la cuenta desde la API (`/api/enroll`) y actualiza el flag `is_admin` mediante `PUT /api/admin/students/<slug>`.
+4. Haz clic en el botón **Panel administrativo** del encabezado y verifica que aparecen las tres secciones.
+   - **Misiones:** selecciona una misión, modifica título o roles y guarda los cambios. Confirma que la operación devuelve un mensaje de éxito y que, ante errores de validación, se muestran mensajes en rojo.
+   - **Usuarios:** crea un usuario de prueba, edítalo (incluyendo el cambio de contraseña) y comprueba que la tabla se actualiza sin recargar la página. Al eliminar un registro, acepta la confirmación del navegador y valida que desaparece del listado.
+   - **Roles:** añade un rol nuevo proporcionando metadata en JSON, edítalo y finalmente elimínalo. Verifica que la sección muestra advertencias si el backend rechaza la operación (por ejemplo, por dependencias con misiones o usuarios).
+5. Revisa la consola del navegador y las respuestas de la pestaña *Network* para asegurarte de que cada acción devuelve el código HTTP esperado (`2xx` para éxito, `4xx` cuando falten permisos o datos).
+
 ### Clave secreta de Flask (`SECRET_KEY`)
 
 La aplicación Flask utiliza `SECRET_KEY` para firmar las cookies de sesión y otros tokens. En producción debes fijar explícitamente una cadena aleatoria y mantenerla en secreto. Por ejemplo:

--- a/frontend/assets/css/style-dark.css
+++ b/frontend/assets/css/style-dark.css
@@ -493,3 +493,402 @@ button#logoutBtn:hover {
     gap: 1rem;
   }
 }
+
+/* Admin module */
+.admin-module {
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  padding: clamp(1.75rem, 2.5vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-module__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.admin-module__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2vw, 1.75rem);
+  font-weight: 700;
+  color: var(--accent-contrast);
+}
+
+.admin-module__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.admin-module__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin-module__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.admin-module__nav-btn {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-module__nav-btn:hover,
+.admin-module__nav-btn:focus-visible {
+  border-color: rgba(96, 165, 250, 0.5);
+  color: var(--accent);
+  background: rgba(37, 99, 235, 0.15);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  outline: none;
+}
+
+.admin-module__nav-btn.is-active,
+.admin-module__nav-btn[aria-current='page'] {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
+  box-shadow: var(--accent-shadow);
+}
+
+.admin-module__content {
+  width: 100%;
+}
+
+.admin-module__section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-module__status {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+  color: var(--muted);
+}
+
+.admin-module__status--loading p {
+  margin: 0;
+}
+
+.admin-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-section__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.admin-section__title {
+  margin: 0;
+  font-size: clamp(1.15rem, 1.8vw, 1.4rem);
+  font-weight: 700;
+  color: var(--accent-contrast);
+}
+
+.admin-section__description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.admin-section__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-section__grid--two-columns {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 2fr);
+}
+
+@media (max-width: 960px) {
+  .admin-section__grid--two-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.admin-card {
+  background-color: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  box-shadow: var(--card-shadow);
+  padding: 1.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--accent-contrast);
+}
+
+.admin-card__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.admin-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.admin-field__label {
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.admin-field__control {
+  width: 100%;
+  border: 1px solid var(--input-border);
+  border-radius: 12px;
+  background-color: var(--input-bg);
+  color: var(--accent-contrast);
+  padding: 0.7rem 0.85rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.admin-field__control:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.75);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+  background-color: rgba(15, 23, 42, 0.95);
+}
+
+.admin-field__control--textarea {
+  min-height: 160px;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.admin-field--fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.admin-field--fieldset legend {
+  padding: 0 0.4rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.admin-field--checkbox .admin-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: var(--accent-contrast);
+}
+
+.admin-checkbox-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+}
+
+.admin-checkbox input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.admin-feedback {
+  min-height: 1.25rem;
+}
+
+.admin-form__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.admin-form__actions--split {
+  justify-content: space-between;
+}
+
+.admin-button {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+  padding: 0.55rem 1.2rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, color 0.2s ease;
+  box-shadow: var(--accent-shadow);
+}
+
+.admin-button:hover,
+.admin-button:focus-visible {
+  background: var(--accent-hover);
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px -20px rgba(96, 165, 250, 0.65);
+}
+
+.admin-button--ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(96, 165, 250, 0.5);
+  box-shadow: none;
+}
+
+.admin-button--ghost:hover,
+.admin-button--ghost:focus-visible {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--accent-contrast);
+}
+
+.admin-button--danger {
+  background: var(--danger);
+  color: var(--accent-contrast);
+  box-shadow: var(--danger-shadow);
+}
+
+.admin-button--danger:hover,
+.admin-button--danger:focus-visible {
+  background: var(--danger-hover);
+}
+
+.admin-button--small {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.85rem;
+}
+
+.status-success,
+.status-error,
+.status-info,
+.status-warning {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+  margin: 0.35rem 0;
+}
+
+.status-success {
+  background: rgba(52, 211, 153, 0.18);
+  border: 1px solid rgba(52, 211, 153, 0.45);
+  color: #34d399;
+}
+
+.status-error {
+  background: rgba(248, 113, 113, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  color: #fca5a5;
+}
+
+.status-info {
+  background: rgba(96, 165, 250, 0.2);
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  color: #93c5fd;
+}
+
+.status-warning {
+  background: rgba(251, 191, 36, 0.18);
+  border: 1px solid rgba(251, 191, 36, 0.45);
+  color: #facc15;
+}
+
+.admin-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 0.75rem 0.85rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  text-align: left;
+  vertical-align: top;
+  font-size: 0.95rem;
+}
+
+.admin-table th {
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 0.8rem;
+}
+
+.admin-table tr.is-selected {
+  background-color: rgba(59, 130, 246, 0.22);
+}
+
+.admin-table__primary {
+  font-weight: 600;
+  color: var(--accent-contrast);
+}
+
+.admin-table__secondary {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.admin-table__actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.admin-user-progress {
+  margin-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  padding-top: 1rem;
+}
+
+.admin-user-progress__title {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+  color: var(--accent-contrast);
+}
+
+.admin-user-progress__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--accent-contrast);
+}
+
+.admin-user-progress__list li {
+  margin-bottom: 0.35rem;
+}
+
+.admin-user-progress__empty {
+  margin: 0;
+  color: var(--muted);
+  font-style: italic;
+}
+

--- a/frontend/assets/css/style.css
+++ b/frontend/assets/css/style.css
@@ -257,3 +257,397 @@ button#logoutBtn:hover {
     gap: 1rem;
   }
 }
+
+/* Admin module */
+.admin-module {
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  padding: clamp(1.75rem, 2.5vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-module__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.admin-module__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2vw, 1.75rem);
+  font-weight: 700;
+}
+
+.admin-module__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.admin-module__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin-module__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.admin-module__nav-btn {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: transparent;
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-module__nav-btn:hover,
+.admin-module__nav-btn:focus-visible {
+  border-color: rgba(37, 99, 235, 0.4);
+  color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
+  outline: none;
+}
+
+.admin-module__nav-btn.is-active,
+.admin-module__nav-btn[aria-current='page'] {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
+  box-shadow: 0 16px 30px -20px rgba(37, 99, 235, 0.55);
+}
+
+.admin-module__content {
+  width: 100%;
+}
+
+.admin-module__section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-module__status {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+  color: var(--muted);
+}
+
+.admin-module__status--loading p {
+  margin: 0;
+}
+
+.admin-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-section__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.admin-section__title {
+  margin: 0;
+  font-size: clamp(1.15rem, 1.8vw, 1.4rem);
+  font-weight: 700;
+}
+
+.admin-section__description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.admin-section__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-section__grid--two-columns {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 2fr);
+}
+
+@media (max-width: 960px) {
+  .admin-section__grid--two-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.admin-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  box-shadow: var(--card-shadow);
+  padding: 1.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.admin-card__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.admin-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.admin-field__label {
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.admin-field__control {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  background-color: #f8fafc;
+  color: var(--text);
+  padding: 0.7rem 0.85rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.admin-field__control:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  background-color: #ffffff;
+}
+
+.admin-field__control--textarea {
+  min-height: 160px;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.admin-field--fieldset {
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.admin-field--fieldset legend {
+  padding: 0 0.4rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.admin-field--checkbox .admin-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.admin-checkbox-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+}
+
+.admin-checkbox input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.admin-feedback {
+  min-height: 1.25rem;
+}
+
+.admin-form__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.admin-form__actions--split {
+  justify-content: space-between;
+}
+
+.admin-button {
+  border: none;
+  border-radius: 12px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+  padding: 0.55rem 1.2rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.admin-button:hover,
+.admin-button:focus-visible {
+  background: var(--accent-hover);
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px -20px rgba(37, 99, 235, 0.6);
+}
+
+.admin-button--ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(37, 99, 235, 0.45);
+  box-shadow: none;
+}
+
+.admin-button--ghost:hover,
+.admin-button--ghost:focus-visible {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+}
+
+.admin-button--danger {
+  background: var(--danger);
+  color: #ffffff;
+  box-shadow: 0 16px 32px -20px rgba(220, 38, 38, 0.5);
+}
+
+.admin-button--danger:hover,
+.admin-button--danger:focus-visible {
+  background: #b91c1c;
+}
+
+.admin-button--small {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.85rem;
+}
+
+.status-success,
+.status-error,
+.status-info,
+.status-warning {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+  margin: 0.35rem 0;
+}
+
+.status-success {
+  background: rgba(22, 163, 74, 0.12);
+  border: 1px solid rgba(22, 163, 74, 0.35);
+  color: #166534;
+}
+
+.status-error {
+  background: rgba(220, 38, 38, 0.12);
+  border: 1px solid rgba(220, 38, 38, 0.35);
+  color: #b91c1c;
+}
+
+.status-info {
+  background: rgba(37, 99, 235, 0.12);
+  border: 1px solid rgba(37, 99, 235, 0.3);
+  color: #1d4ed8;
+}
+
+.status-warning {
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  color: #b45309;
+}
+
+.admin-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 0.75rem 0.85rem;
+  border-bottom: 1px solid var(--card-border);
+  text-align: left;
+  vertical-align: top;
+  font-size: 0.95rem;
+}
+
+.admin-table th {
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 0.8rem;
+}
+
+.admin-table tr.is-selected {
+  background-color: rgba(37, 99, 235, 0.08);
+}
+
+.admin-table__primary {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.admin-table__secondary {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.admin-table__actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.admin-user-progress {
+  margin-top: 1rem;
+  border-top: 1px solid var(--card-border);
+  padding-top: 1rem;
+}
+
+.admin-user-progress__title {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.admin-user-progress__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--text);
+}
+
+.admin-user-progress__list li {
+  margin-bottom: 0.35rem;
+}
+
+.admin-user-progress__empty {
+  margin: 0;
+  color: var(--muted);
+  font-style: italic;
+}
+


### PR DESCRIPTION
## Summary
- replace the single mission admin view with a reusable admin module that renders missions, usuarios and roles sections
- wire mission management into the new container and add CRUD forms for usuarios y roles with feedback and confirmation before deletes
- refresh frontend styles for the admin area and document manual validation steps in the README

## Testing
- not run (manual instructions documented in README)


------
https://chatgpt.com/codex/tasks/task_e_68cd2e59d3d88331ab90b7da7ede25bb