### PR TITLE
Add mission creation flow to admin panel

### DIFF
--- a/frontend/assets/css/style-dark.css
+++ b/frontend/assets/css/style-dark.css
@@ -603,6 +603,14 @@ button#logoutBtn:hover {
   gap: 0.75rem;
 }
 
+.admin-section__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  align-items: center;
+}
+
 .admin-section__title {
   margin: 0;
   font-size: clamp(1.15rem, 1.8vw, 1.4rem);

--- a/frontend/assets/css/style.css
+++ b/frontend/assets/css/style.css
@@ -365,6 +365,14 @@ button#logoutBtn:hover {
   gap: 0.75rem;
 }
 
+.admin-section__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  align-items: center;
+}
+
 .admin-section__title {
   margin: 0;
   font-size: clamp(1.15rem, 1.8vw, 1.4rem);


### PR DESCRIPTION
## Summary
- add a "Nueva misión" action and identifier field so administrators can draft new missions from the missions panel
- reuse existing validation to send POST requests to /api/admin/missions when creating missions and append successful results to the selector
- add shared styling for the new header action container to keep buttons aligned across themes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd3b08c7f883318392bd52e3642de8