### PR TITLE
Add admin-managed integration settings for GitHub and OpenAI

### DIFF
--- a/backend/tests/test_llm_verifier.py
+++ b/backend/tests/test_llm_verifier.py
@@ -35,56 +35,60 @@ class VerifyLLMTests(unittest.TestCase):
             "feedback_fail": "La entrega necesita más detalle.",
         }
 
-    @patch("backend.app.OpenAILLMClient.from_env")
-    def test_verify_llm_marks_completed(self, mock_from_env: MagicMock) -> None:
+    @patch("backend.app.OpenAILLMClient.from_settings")
+    def test_verify_llm_marks_completed(self, mock_from_settings: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.evaluate_deliverable.return_value = LLMEvaluationResponse(
             status="completado",
             feedback="",
         )
-        mock_from_env.return_value = mock_client
+        mock_from_settings.return_value = mock_client
 
         files = DummyFiles("Notas completas sobre limpieza, tipos y duplicados.")
         passed, feedback = verify_llm(files, self._build_contract())
 
         self.assertTrue(passed)
         self.assertEqual(feedback, [])
-        mock_from_env.assert_called_once()
+        mock_from_settings.assert_called_once()
         mock_client.evaluate_deliverable.assert_called_once()
         call_kwargs = mock_client.evaluate_deliverable.call_args.kwargs
         self.assertIn("content", call_kwargs)
         self.assertEqual(call_kwargs["keywords"], ["limpieza", "tipos"])
         self.assertIn("Detalla el proceso de limpieza", call_kwargs["criteria"])
 
-    @patch("backend.app.OpenAILLMClient.from_env")
-    def test_verify_llm_marks_incomplete_with_feedback(self, mock_from_env: MagicMock) -> None:
+    @patch("backend.app.OpenAILLMClient.from_settings")
+    def test_verify_llm_marks_incomplete_with_feedback(
+        self, mock_from_settings: MagicMock
+    ) -> None:
         mock_client = MagicMock()
         mock_client.evaluate_deliverable.return_value = LLMEvaluationResponse(
             status="incompleto",
             feedback="Falta detallar cómo tratas los tipos de datos.",
         )
-        mock_from_env.return_value = mock_client
+        mock_from_settings.return_value = mock_client
 
         files = DummyFiles("Notas parciales sobre limpieza.")
         passed, feedback = verify_llm(files, self._build_contract())
 
         self.assertFalse(passed)
         self.assertEqual(feedback, ["Falta detallar cómo tratas los tipos de datos."])
-        mock_from_env.assert_called_once()
+        mock_from_settings.assert_called_once()
         mock_client.evaluate_deliverable.assert_called_once()
 
-    @patch("backend.app.OpenAILLMClient.from_env")
+    @patch("backend.app.OpenAILLMClient.from_settings")
     def test_verify_llm_returns_friendly_error_when_openai_missing(
-        self, mock_from_env: MagicMock
+        self, mock_from_settings: MagicMock
     ) -> None:
-        mock_from_env.side_effect = LLMConfigurationError(MISSING_OPENAI_DEPENDENCY_MESSAGE)
+        mock_from_settings.side_effect = LLMConfigurationError(
+            MISSING_OPENAI_DEPENDENCY_MESSAGE
+        )
 
         files = DummyFiles("Notas incompletas.")
         passed, feedback = verify_llm(files, self._build_contract())
 
         self.assertFalse(passed)
         self.assertEqual(feedback, [MISSING_OPENAI_DEPENDENCY_MESSAGE])
-        mock_from_env.assert_called_once()
+        mock_from_settings.assert_called_once()
 
 
 class OpenAILLMClientFromEnvTests(unittest.TestCase):

--- a/backend/tests/test_verify_mission_config_errors.py
+++ b/backend/tests/test_verify_mission_config_errors.py
@@ -73,7 +73,7 @@ def _patch_client_failure(monkeypatch, message: str) -> None:
     def _raise(cls):
         raise GitHubConfigurationError(message)
 
-    monkeypatch.setattr(backend_app.GitHubClient, "from_env", classmethod(_raise))
+    monkeypatch.setattr(backend_app.GitHubClient, "from_settings", classmethod(_raise))
 
 
 @pytest.mark.parametrize("verification_type", ["evidence", "script_output"])

--- a/frontend/src/pages/AdminIntegrations.jsx
+++ b/frontend/src/pages/AdminIntegrations.jsx
@@ -1,0 +1,291 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+const STORAGE_KEYS = {
+  token: 'session_token',
+};
+
+const CATEGORY_LABELS = {
+  github: 'GitHub',
+  openai: 'OpenAI',
+  general: 'General',
+};
+
+const buildFormState = (rawSettings) => {
+  if (!Array.isArray(rawSettings)) {
+    return [];
+  }
+  return rawSettings.map((item) => {
+    const key = item && typeof item.key === 'string' ? item.key : '';
+    const label = item && typeof item.label === 'string' ? item.label : key;
+    const category = item && typeof item.category === 'string' ? item.category : 'general';
+    const helpText = item && typeof item.help_text === 'string' ? item.help_text : '';
+    const placeholder = item && typeof item.placeholder === 'string' ? item.placeholder : '';
+    const isSecret = Boolean(item && item.is_secret);
+    const configured = Boolean(item && item.configured);
+    const value = item && typeof item.value === 'string' ? item.value : '';
+    const defaultValue = item && typeof item.default === 'string' ? item.default : '';
+    return {
+      key,
+      label,
+      category,
+      helpText,
+      placeholder,
+      isSecret,
+      configured,
+      defaultValue,
+      originalValue: isSecret ? (configured ? '__SECRET__' : '') : value,
+      draftValue: isSecret ? '' : value,
+      dirty: false,
+      shouldClear: false,
+    };
+  });
+};
+
+const groupByCategory = (settings) => {
+  const groups = new Map();
+  settings.forEach((setting) => {
+    const category = setting.category || 'general';
+    if (!groups.has(category)) {
+      groups.set(category, []);
+    }
+    groups.get(category).push(setting);
+  });
+  return Array.from(groups.entries());
+};
+
+const AdminIntegrations = () => {
+  const [formState, setFormState] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const groupedSettings = useMemo(() => groupByCategory(formState), [formState]);
+
+  const getToken = () => {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return '';
+    }
+    return window.localStorage.getItem(STORAGE_KEYS.token) || '';
+  };
+
+  const fetchSettings = useCallback(async () => {
+    const token = getToken();
+    if (!token) {
+      setError('No se encontró un token de sesión válido. Inicia sesión nuevamente.');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError('');
+    setSuccess('');
+    try {
+      const response = await fetch('/api/admin/integrations', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        credentials: 'include',
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const message =
+          typeof payload.error === 'string' && payload.error.trim()
+            ? payload.error.trim()
+            : 'No se pudieron cargar las integraciones.';
+        setError(message);
+        setFormState([]);
+        setLoading(false);
+        return;
+      }
+      setFormState(buildFormState(payload.settings));
+    } catch (err) {
+      setError('Error de conexión al cargar las integraciones.');
+      setFormState([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSettings();
+  }, [fetchSettings]);
+
+  const handleInputChange = useCallback((key, value) => {
+    setFormState((prev) =>
+      prev.map((setting) => {
+        if (setting.key !== key) {
+          return setting;
+        }
+        const draftValue = value;
+        if (setting.isSecret) {
+          const dirty = Boolean(draftValue);
+          return {
+            ...setting,
+            draftValue,
+            dirty,
+            shouldClear: false,
+          };
+        }
+        const dirty = draftValue !== setting.originalValue;
+        return {
+          ...setting,
+          draftValue,
+          dirty,
+        };
+      }),
+    );
+  }, []);
+
+  const handleClearSecret = useCallback((key) => {
+    setFormState((prev) =>
+      prev.map((setting) => {
+        if (setting.key !== key) {
+          return setting;
+        }
+        if (!setting.isSecret) {
+          return setting;
+        }
+        return {
+          ...setting,
+          draftValue: '',
+          dirty: false,
+          shouldClear: true,
+        };
+      }),
+    );
+  }, []);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccess('');
+    const token = getToken();
+    if (!token) {
+      setError('La sesión expiró. Inicia sesión nuevamente.');
+      return;
+    }
+    const updates = formState
+      .filter((setting) => setting.shouldClear || setting.dirty)
+      .map((setting) => {
+        if (setting.shouldClear) {
+          return { key: setting.key, clear: true };
+        }
+        return { key: setting.key, value: setting.draftValue };
+      });
+    if (updates.length === 0) {
+      setSuccess('No hay cambios para guardar.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const response = await fetch('/api/admin/integrations', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        credentials: 'include',
+        body: JSON.stringify({ updates }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const message =
+          typeof payload.error === 'string' && payload.error.trim()
+            ? payload.error.trim()
+            : 'No se pudieron guardar los cambios.';
+        setError(message);
+        return;
+      }
+      setFormState(buildFormState(payload.settings));
+      setSuccess('Integraciones actualizadas correctamente.');
+    } catch (err) {
+      setError('Error de conexión al guardar los cambios.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = () => {
+    fetchSettings();
+  };
+
+  return (
+    <main className="admin-integrations">
+      <header className="admin-integrations__header">
+        <h1>Integraciones</h1>
+        <p>
+          Administra las credenciales de GitHub y OpenAI utilizadas por el verificador automático. Los cambios son inmediatos y
+          afectan a todas las verificaciones nuevas.
+        </p>
+      </header>
+      {error && <div className="admin-integrations__alert admin-integrations__alert--error">{error}</div>}
+      {success && <div className="admin-integrations__alert admin-integrations__alert--success">{success}</div>}
+      {loading ? (
+        <p>Cargando configuraciones…</p>
+      ) : (
+        <form className="admin-integrations__form" onSubmit={handleSubmit}>
+          {groupedSettings.length === 0 ? (
+            <p>No hay campos de configuración disponibles.</p>
+          ) : (
+            groupedSettings.map(([category, items]) => (
+              <section key={category} className="admin-integrations__section">
+                <h2>{CATEGORY_LABELS[category] || category}</h2>
+                {items.map((setting) => (
+                  <div key={setting.key} className="admin-integrations__field">
+                    <label className="admin-integrations__label" htmlFor={`setting-${setting.key}`}>
+                      {setting.label}
+                    </label>
+                    <input
+                      id={`setting-${setting.key}`}
+                      type={setting.isSecret ? 'password' : 'text'}
+                      value={setting.draftValue}
+                      onChange={(event) => handleInputChange(setting.key, event.target.value)}
+                      placeholder={setting.placeholder || setting.defaultValue || ''}
+                      autoComplete="off"
+                      className="admin-integrations__input"
+                      disabled={saving}
+                    />
+                    {setting.isSecret && setting.configured && !setting.shouldClear && !setting.dirty && (
+                      <p className="admin-integrations__hint">Valor guardado. Deja el campo vacío para conservarlo.</p>
+                    )}
+                    {setting.isSecret && (
+                      <div className="admin-integrations__secret-actions">
+                        <button
+                          type="button"
+                          className="admin-integrations__clear"
+                          onClick={() => handleClearSecret(setting.key)}
+                          disabled={saving || !setting.configured}
+                        >
+                          Quitar valor guardado
+                        </button>
+                        {setting.shouldClear && <span className="admin-integrations__hint">Se eliminará al guardar.</span>}
+                      </div>
+                    )}
+                    {setting.helpText && (
+                      <p className="admin-integrations__help">{setting.helpText}</p>
+                    )}
+                    {!setting.isSecret && !setting.draftValue && setting.defaultValue && (
+                      <p className="admin-integrations__hint">
+                        Valor sugerido: <code>{setting.defaultValue}</code>
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </section>
+            ))
+          )}
+          <div className="admin-integrations__actions">
+            <button type="button" onClick={handleReset} disabled={loading || saving}>
+              Descartar cambios
+            </button>
+            <button type="submit" disabled={saving}>
+              {saving ? 'Guardando…' : 'Guardar cambios'}
+            </button>
+          </div>
+        </form>
+      )}
+    </main>
+  );
+};
+
+export default AdminIntegrations;

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -1,13 +1,47 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import EnrollPage from '../pages/EnrollPage';
 import LandingPage from '../pages/LandingPage';
+import AdminIntegrations from '../pages/AdminIntegrations';
+
+const STORAGE_KEYS = {
+  token: 'session_token',
+  admin: 'session_is_admin',
+};
+
+const normalizeAdminFlag = (value) => {
+  if (value == null) {
+    return false;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  return ['1', 'true', 'yes', 'y', 'on'].includes(normalized);
+};
+
+const ProtectedRoute = ({ children }) => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return <Navigate to="/" replace />;
+  }
+  const token = window.localStorage.getItem(STORAGE_KEYS.token);
+  const adminFlag = window.localStorage.getItem(STORAGE_KEYS.admin);
+  if (!token || !normalizeAdminFlag(adminFlag)) {
+    return <Navigate to="/" replace />;
+  }
+  return children;
+};
 
 const AppRouter = () => (
   <Routes>
     <Route path="/" element={<LandingPage />} />
     <Route path="/misiones/:missionId" element={<div>Detalle de la misión</div>} />
     <Route path="/inscripcion/:missionId" element={<EnrollPage />} />
+    <Route
+      path="/admin/integrations"
+      element={(
+        <ProtectedRoute>
+          <AdminIntegrations />
+        </ProtectedRoute>
+      )}
+    />
   </Routes>
 );
 


### PR DESCRIPTION
## Summary
- persist GitHub/OpenAI credentials in the new `service_settings` table with helper APIs and admin endpoints
- let `GitHubClient` and `OpenAILLMClient` read configuration from the database and reuse it during mission verification
- expose an admin Integrations page to edit the settings and update the documentation to describe the new workflow

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cd6a08cb7c83318741308841b2c161