### PR TITLE
Adjust admin table containers for horizontal scroll

### DIFF
--- a/frontend/assets/css/style-dark.css
+++ b/frontend/assets/css/style-dark.css
@@ -653,6 +653,11 @@ button#logoutBtn:hover {
   gap: 1rem;
 }
 
+.admin-card--list {
+  width: 100%;
+  max-width: 100%;
+}
+
 .admin-card__title {
   margin: 0;
   font-size: 1.05rem;
@@ -831,8 +836,16 @@ button#logoutBtn:hover {
   color: #facc15;
 }
 
+.admin-table {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 .admin-table table {
   width: 100%;
+  min-width: 600px;
   border-collapse: collapse;
 }
 

--- a/frontend/assets/css/style.css
+++ b/frontend/assets/css/style.css
@@ -414,6 +414,11 @@ button#logoutBtn:hover {
   gap: 1rem;
 }
 
+.admin-card--list {
+  width: 100%;
+  max-width: 100%;
+}
+
 .admin-card__title {
   margin: 0;
   font-size: 1.05rem;
@@ -590,8 +595,16 @@ button#logoutBtn:hover {
   color: #b45309;
 }
 
+.admin-table {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 .admin-table table {
   width: 100%;
+  min-width: 600px;
   border-collapse: collapse;
 }
 


### PR DESCRIPTION
## Summary
- limit admin list cards to their column width in both light and dark themes
- enable horizontal scrolling on admin tables so wide content stays contained

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdc4ac75988331980312bbba7dcb70