### PR TITLE
Ensure blank mission presentations are refreshed from contracts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1693,7 +1693,10 @@ def _ensure_presentations_in_storage(cursor, is_sqlite: bool) -> None:
             content_payload = json.loads(content_raw)
         except json.JSONDecodeError:
             continue
-        if not isinstance(content_payload, dict) or "display_html" in content_payload:
+        if not isinstance(content_payload, dict):
+            continue
+        existing_display_html = content_payload.get("display_html")
+        if isinstance(existing_display_html, str) and existing_display_html.strip():
             continue
         contract_payload = contracts.get(mission_id) if isinstance(contracts, Mapping) else {}
         if not isinstance(contract_payload, Mapping):

--- a/backend/tests/test_missions_api.py
+++ b/backend/tests/test_missions_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime
 from pathlib import Path
@@ -103,6 +104,47 @@ def test_blank_titles_are_reseeded(sqlite_backend):
     assert content.get("verification_type") == "evidence"
     display_html = content.get("display_html")
     assert isinstance(display_html, str) and display_html.strip()
+
+
+def test_blank_display_html_is_replaced_from_contract(sqlite_backend):
+    backend_app.init_db()
+    contracts_payload = backend_app._load_contract_payload()
+    mission_id = None
+    expected_html = None
+    for candidate_id, contract in contracts_payload.items():
+        html_value = contract.get("display_html") if isinstance(contract, dict) else None
+        if isinstance(html_value, str) and html_value.strip():
+            mission_id = candidate_id
+            expected_html = html_value
+            break
+    assert mission_id is not None, "Se esperaba al menos una misión con display_html en el contrato"
+    with backend_app.get_db_connection() as conn:
+        with conn.cursor() as cur:
+            is_sqlite = getattr(conn, "is_sqlite", False)
+            backend_app._ensure_missions_seeded(cur, is_sqlite)
+            cur.execute(
+                "SELECT content_json FROM missions WHERE mission_id = %s",
+                (mission_id,),
+            )
+            row = cur.fetchone() or {}
+            content_raw = row.get("content_json")
+            assert isinstance(content_raw, str) and content_raw.strip(), "La misión debe existir en la base de datos"
+            content_payload = json.loads(content_raw)
+            content_payload["display_html"] = "   "
+            cur.execute(
+                "UPDATE missions SET content_json = %s WHERE mission_id = %s",
+                (json.dumps(content_payload, ensure_ascii=False), mission_id),
+            )
+            backend_app._ensure_presentations_in_storage(cur, is_sqlite)
+            cur.execute(
+                "SELECT content_json FROM missions WHERE mission_id = %s",
+                (mission_id,),
+            )
+            updated_row = cur.fetchone() or {}
+            updated_raw = updated_row.get("content_json")
+    assert isinstance(updated_raw, str) and updated_raw.strip()
+    updated_payload = json.loads(updated_raw)
+    assert updated_payload.get("display_html") == expected_html
 
 
 def test_admin_mission_crud_flow(sqlite_backend):


### PR DESCRIPTION
## Summary
- read the stored mission display_html before skipping updates and only bail out when the value is non-empty
- refresh blank presentation HTML from the contracts/frontend data so missions get updated snippets
- add a regression test covering a mission whose stored display_html is whitespace

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d314a153dc833199e6bc51c074468b