### PR TITLE
Add mission 3 deliverables to contracts

### DIFF
--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -80,6 +80,23 @@
       "default_branch": "main",
       "base_path": "students/{slug}"
     },
+    "deliverables": [
+      {
+        "type": "file_exists",
+        "path": "docs/m3_csv_notes.md",
+        "feedback_fail": "No encontré tus notas sobre CSV para la misión 3 (m3_csv_notes.md)."
+      },
+      {
+        "type": "file_exists",
+        "path": "docs/m3_practice_output.txt",
+        "feedback_fail": "No encontré el archivo con los resultados de tu práctica (m3_practice_output.txt)."
+      },
+      {
+        "type": "file_exists",
+        "path": "scripts/m3_explorer.py",
+        "feedback_fail": "No encontré tu script explorador de la misión 3 (m3_explorer.py)."
+      }
+    ],
     "script_path": "scripts/m3_explorer.py",
     "validations": [
       {

--- a/backend/missions_contracts.yaml
+++ b/backend/missions_contracts.yaml
@@ -32,6 +32,16 @@ m2:
 m3:
   verification_type: script_output
   script_path: "scripts/m3_explorer.py"
+  deliverables:
+    - type: file_exists
+      path: "docs/m3_csv_notes.md"
+      feedback_fail: "No encontré tus notas sobre CSV para la misión 3 (m3_csv_notes.md)."
+    - type: file_exists
+      path: "docs/m3_practice_output.txt"
+      feedback_fail: "No encontré el archivo con los resultados de tu práctica (m3_practice_output.txt)."
+    - type: file_exists
+      path: "scripts/m3_explorer.py"
+      feedback_fail: "No encontré tu script explorador de la misión 3 (m3_explorer.py)."
   validations:
     - type: output_contains
       text: "Shape: "


### PR DESCRIPTION
## Summary
- add the missing deliverables section for mission 3 in the YAML contract
- sync mission 3 deliverables into the JSON contracts file with consistent failure messages

## Testing
- pytest backend/tests/test_missions_api.py::test_public_mission_detail_includes_display_html

------
https://chatgpt.com/codex/tasks/task_e_68d31d0a9ad883318f62b7be338619ef