### PR TITLE
Allow custom script verification feedback

### DIFF
--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -98,6 +98,8 @@
       }
     ],
     "script_path": "scripts/m3_explorer.py",
+    "feedback_script_missing": "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}.",
+    "feedback_required_file_missing": "Falta el archivo necesario {required_path} para ejecutar la validación ({source}).",
     "validations": [
       {
         "type": "output_contains",

--- a/backend/missions_contracts.yaml
+++ b/backend/missions_contracts.yaml
@@ -32,6 +32,8 @@ m2:
 m3:
   verification_type: script_output
   script_path: "scripts/m3_explorer.py"
+  feedback_script_missing: "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}."
+  feedback_required_file_missing: "Falta el archivo necesario {required_path} para ejecutar la validación ({source})."
   deliverables:
     - type: file_exists
       path: "docs/m3_csv_notes.md"

--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from backend import app as backend_app
+from backend.github_client import GitHubFileNotFoundError
+
+
+class _DummyFiles:
+    def __init__(self, existing: dict[str, bytes] | None = None) -> None:
+        self._existing = existing or {}
+
+    def read_bytes(self, path: str) -> bytes:
+        if path in self._existing:
+            return self._existing[path]
+        raise GitHubFileNotFoundError(
+            f"missing {path}", repository="repo", path=path, ref="main"
+        )
+
+    def describe_source(self, path: str | None = None) -> str:
+        if path is None:
+            return "repo/main"
+        return f"repo/main en {path}"
+
+
+def test_verify_script_uses_custom_message_when_script_missing() -> None:
+    files = _DummyFiles()
+    contract = {
+        "script_path": "scripts/m3_explorer.py",
+        "feedback_script_missing": "Falta el script {script_path}. Revísalo en {source}.",
+    }
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is False
+    assert feedback == [
+        "Falta el script scripts/m3_explorer.py. Revísalo en repo/main en scripts/m3_explorer.py."
+    ]
+
+
+def test_verify_script_uses_custom_message_when_dependency_missing() -> None:
+    files = _DummyFiles({"scripts/m3_explorer.py": b"print('ok')"})
+    contract = {
+        "script_path": "scripts/m3_explorer.py",
+        "required_files": ["data/input.csv"],
+        "feedback_required_file_missing": "Hace falta {required_path} para ejecutar el script ({source}).",
+    }
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is False
+    assert feedback == [
+        "Hace falta data/input.csv para ejecutar el script (repo/main en data/input.csv)."
+    ]


### PR DESCRIPTION
## Summary
- allow the script verifier to format feedback using contract-provided templates when the script or dependencies are missing
- document the new feedback fields for script-output missions in the M3 contract definitions
- add unit tests that assert the custom messages are returned when files are absent

## Testing
- pytest backend/tests/test_verify_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d31e56680883318247c8265bd61d57