### PR TITLE
Refresh mission content_json from contracts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1758,6 +1758,10 @@ def _ensure_missions_seeded(cursor, is_sqlite: bool) -> None:
     if count == 0:
         _seed_missions_from_file(cursor, is_sqlite)
 
+    contracts_payload = _load_contract_payload()
+    frontend_presentations = _load_frontend_presentations()
+    timestamp = _format_timestamp(datetime.utcnow())
+
     blank_title_ids: List[str] = []
     try:
         cursor.execute(
@@ -1783,9 +1787,6 @@ def _ensure_missions_seeded(cursor, is_sqlite: bool) -> None:
             blank_title_ids.append(mission_id)
 
     if blank_title_ids:
-        contracts_payload = _load_contract_payload()
-        frontend_presentations = _load_frontend_presentations()
-        timestamp = _format_timestamp(datetime.utcnow())
         for mission_id in blank_title_ids:
             contract_entry = (
                 contracts_payload.get(mission_id)
@@ -1839,6 +1840,112 @@ def _ensure_missions_seeded(cursor, is_sqlite: bool) -> None:
                     mission_id,
                     exc,
                 )
+
+    try:
+        cursor.execute("SELECT mission_id, content_json FROM missions")
+        rows_with_content = cursor.fetchall() or []
+    except Exception as exc:
+        logger.error("Failed to inspect mission content: %s", exc)
+        rows_with_content = []
+
+    for row in rows_with_content:
+        mission_id_raw = None
+        if isinstance(row, Mapping):
+            mission_id_raw = row.get("mission_id")
+            if mission_id_raw is None:
+                mission_id_raw = row.get("MISSION_ID")
+        elif isinstance(row, (list, tuple)) and row:
+            mission_id_raw = row[0]
+        if isinstance(mission_id_raw, (bytes, bytearray)):
+            mission_id_raw = mission_id_raw.decode("utf-8", errors="ignore")
+        mission_id = str(mission_id_raw or "").strip()
+        if not mission_id:
+            continue
+
+        contract_entry = (
+            contracts_payload.get(mission_id)
+            if isinstance(contracts_payload, Mapping)
+            else None
+        )
+        if not isinstance(contract_entry, Mapping):
+            continue
+
+        seed_values = _build_mission_seed_values(
+            mission_id,
+            contract_entry,
+            frontend_presentations,
+        )
+        if seed_values is None:
+            continue
+        _, _, desired_content_json = seed_values
+        if not isinstance(desired_content_json, str):
+            continue
+
+        content_raw = None
+        if isinstance(row, Mapping):
+            content_raw = row.get("content_json")
+            if content_raw is None:
+                content_raw = row.get("CONTENT_JSON")
+        elif isinstance(row, (list, tuple)):
+            content_raw = row[1] if len(row) > 1 else None
+        if isinstance(content_raw, (bytes, bytearray)):
+            content_raw = content_raw.decode("utf-8", errors="ignore")
+
+        stored_payload: Optional[dict] = None
+        stored_json: Optional[str] = None
+        if isinstance(content_raw, str):
+            stored_json = content_raw
+            stripped = content_raw.strip()
+            if stripped:
+                try:
+                    decoded = json.loads(stripped)
+                except json.JSONDecodeError:
+                    decoded = None
+                if isinstance(decoded, dict):
+                    stored_payload = decoded
+        elif isinstance(content_raw, Mapping):
+            try:
+                stored_payload = dict(content_raw)
+            except Exception:
+                stored_payload = None
+            if stored_payload is not None:
+                try:
+                    stored_json = json.dumps(stored_payload, ensure_ascii=False)
+                except TypeError:
+                    stored_json = None
+
+        try:
+            desired_payload = json.loads(desired_content_json)
+        except json.JSONDecodeError:
+            continue
+
+        needs_update = False
+        if stored_payload is not None:
+            needs_update = stored_payload != desired_payload
+        elif isinstance(stored_json, str):
+            needs_update = stored_json.strip() != desired_content_json.strip()
+        else:
+            needs_update = True
+
+        if not needs_update:
+            continue
+
+        try:
+            cursor.execute(
+                """
+                UPDATE missions
+                SET content_json = %s,
+                    updated_at = %s
+                WHERE mission_id = %s
+                """,
+                (desired_content_json, timestamp, mission_id),
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to refresh mission %s content from contracts: %s",
+                mission_id,
+                exc,
+            )
 
     _ensure_presentations_in_storage(cursor, is_sqlite)
 

--- a/backend/tests/test_missions_api.py
+++ b/backend/tests/test_missions_api.py
@@ -147,6 +147,62 @@ def test_blank_display_html_is_replaced_from_contract(sqlite_backend):
     assert updated_payload.get("display_html") == expected_html
 
 
+def test_mission_content_json_is_refreshed_from_contract(sqlite_backend):
+    backend_app.init_db()
+    contracts_payload = backend_app._load_contract_payload()
+    presentations = backend_app._load_frontend_presentations()
+    mission_id = None
+    contract_entry = None
+    for candidate_id, contract in contracts_payload.items():
+        if isinstance(contract, dict) and "feedback_script_missing" in contract:
+            mission_id = candidate_id
+            contract_entry = contract
+            break
+    assert mission_id is not None, "Se esperaba al menos una misión con feedback_script_missing"
+    seed_values = backend_app._build_mission_seed_values(
+        mission_id,
+        contract_entry,
+        presentations,
+    )
+    assert seed_values is not None
+    title, roles_json, desired_content_json = seed_values
+    desired_payload = json.loads(desired_content_json)
+    assert "feedback_script_missing" in desired_payload
+    outdated_payload = dict(desired_payload)
+    outdated_payload.pop("feedback_script_missing", None)
+    outdated_content_json = json.dumps(outdated_payload, ensure_ascii=False)
+
+    updated_raw = None
+    with backend_app.get_db_connection() as conn:
+        with conn.cursor() as cur:
+            is_sqlite = getattr(conn, "is_sqlite", False)
+            cur.execute("DELETE FROM missions WHERE mission_id = %s", (mission_id,))
+            cur.execute(
+                """
+                INSERT INTO missions (mission_id, title, roles, content_json, updated_at)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (
+                    mission_id,
+                    title,
+                    roles_json,
+                    outdated_content_json,
+                    backend_app._format_timestamp(datetime.utcnow()),
+                ),
+            )
+            backend_app._ensure_missions_seeded(cur, is_sqlite)
+            cur.execute(
+                "SELECT content_json FROM missions WHERE mission_id = %s",
+                (mission_id,),
+            )
+            row = cur.fetchone() or {}
+            updated_raw = row.get("content_json")
+
+    assert isinstance(updated_raw, str) and updated_raw.strip()
+    updated_payload = json.loads(updated_raw)
+    assert updated_payload.get("feedback_script_missing") == desired_payload.get("feedback_script_missing")
+
+
 def test_outdated_display_html_is_replaced_from_contract(sqlite_backend):
     backend_app.init_db()
     contracts_payload = backend_app._load_contract_payload()


### PR DESCRIPTION
## Summary
- load missions contracts once during seeding and refresh stored content_json when it drifts from the contract definition
- add a regression test that reseeds a mission with an outdated contract payload and ensures new fields are backfilled

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d322abf1688331bd9e1bfb74c94a88