### PR TITLE
Add pandas dependency and verify mission script execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ Si no hay valores persistentes, el backend lee las variables de entorno como mec
 | `OPENAI_MODEL` | Modelo de chat por defecto (se sustituye al guardar una configuración desde el panel). |
 | `OPENAI_TIMEOUT` | Tiempo máximo de espera en segundos antes de abortar la solicitud. |
 
-El proyecto depende de la librería oficial `openai` incluida en `backend/requirements.txt`. Ejecuta `pip install -r backend/requirements.txt` para instalarla antes de iniciar el servidor.
+El proyecto depende de librerías como `openai` y `pandas` incluidas en `backend/requirements.txt`. Ejecuta `pip install -r backend/requirements.txt` para instalarlas antes de iniciar el servidor.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ PyMySQL==1.1.0
 bcrypt==4.0.1
 requests==2.31.0
 openai>=1.12.0,<2.0.0
+pandas==2.2.2

--- a/backend/tests/test_verify_mission_executes_script.py
+++ b/backend/tests/test_verify_mission_executes_script.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from backend import app as backend_app
+from backend.github_client import RepositoryInfo, RepositorySelection
+
+
+class _DummyCursor:
+    def __enter__(self) -> "_DummyCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no cleanup required
+        return None
+
+    def execute(self, query: str, params=None) -> None:  # pragma: no cover - no-op
+        return None
+
+    def fetchone(self) -> dict:
+        return {"role": "explorer"}
+
+    def fetchall(self) -> list:
+        return []
+
+
+class _DummyConnection:
+    is_sqlite = True
+
+    def __enter__(self) -> "_DummyConnection":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no cleanup required
+        return None
+
+    def cursor(self) -> _DummyCursor:
+        return _DummyCursor()
+
+
+def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
+    backend_app.app.config["TESTING"] = True
+
+    monkeypatch.setattr(backend_app, "init_db", lambda: None)
+    monkeypatch.setattr(backend_app, "get_db_connection", lambda: _DummyConnection())
+    monkeypatch.setattr(
+        backend_app,
+        "validate_session",
+        lambda token, slug=None, require_admin=False: True,
+    )
+
+    contract = {
+        "verification_type": "script_output",
+        "script_path": "scripts/m3_explorer.py",
+        "validations": [
+            {"type": "output_contains", "text": "Shape: "},
+            {"type": "output_contains", "text": "Columns:"},
+        ],
+        "source": {
+            "repository": "default",
+            "default_branch": "main",
+            "base_path": "students/{slug}",
+        },
+    }
+
+    monkeypatch.setattr(
+        backend_app,
+        "_get_mission_by_id",
+        lambda mission_id: {"mission_id": mission_id, "content": contract},
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "_fetch_missions_from_db",
+        lambda mission_id=None: [],
+    )
+
+    def _dummy_determine_repos(slug: str, role: str | None = None):
+        return {
+            "default": RepositoryInfo(
+                key="default",
+                repository="dummy/repo",
+                default_branch="main",
+            )
+        }
+
+    def _dummy_select_repo(source, slug: str, repositories):
+        info = repositories["default"]
+        return RepositorySelection(info=info, branch="main", base_path=f"students/{slug}")
+
+    monkeypatch.setattr(backend_app, "determine_student_repositories", _dummy_determine_repos)
+    monkeypatch.setattr(backend_app, "select_repository_for_contract", _dummy_select_repo)
+
+    script_bytes = b"""import pandas as pd\n\n\nif __name__ == \"__main__\":\n    df = pd.DataFrame({\"a\": [1, 2]})\n    print(f\"Shape: {df.shape}\")\n    print(\"Columns:\", ", ".join(df.columns))\n"""
+
+    class _DummyGitHubClient:
+        def get_file_content(self, repository: str, path: str, ref: str | None) -> bytes:
+            assert repository == "dummy/repo"
+            assert ref == "main"
+            expected_path = "students/student/scripts/m3_explorer.py"
+            if path != expected_path:
+                raise AssertionError(f"Unexpected path requested: {path}")
+            return script_bytes
+
+    monkeypatch.setattr(
+        backend_app.GitHubClient,
+        "from_settings",
+        classmethod(lambda cls: _DummyGitHubClient()),
+    )
+
+    client = backend_app.app.test_client()
+    response = client.post(
+        "/api/verify_mission",
+        json={"slug": "student", "mission_id": "m3"},
+        headers={"Authorization": "Bearer token"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload == {"verified": True, "feedback": []}


### PR DESCRIPTION
## Summary
- add pandas to the backend requirements so mission scripts can rely on it
- mention the new dependency in the backend installation instructions
- add an API test that verifies the M3 mission script runs when it imports pandas

## Testing
- pytest backend/tests/test_verify_mission_executes_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d882ea30e88331a7b2aec00b8ded7f