### PR TITLE
Add orders seed CSV for M3 and update contract requirements

### DIFF
--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -98,11 +98,14 @@
       }
     ],
     "script_path": "scripts/m3_explorer.py",
-    "feedback_script_missing": "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}.",
-    "feedback_required_file_missing": "Falta el archivo necesario {required_path} para ejecutar la validación ({source}).",
-    "validations": [
-      {
-        "type": "output_contains",
+  "feedback_script_missing": "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}.",
+  "feedback_required_file_missing": "Falta el archivo necesario {required_path} para ejecutar la validación ({source}).",
+  "required_files": [
+    "sources/orders_seed.csv"
+  ],
+  "validations": [
+    {
+      "type": "output_contains",
         "text": "Shape: ",
         "feedback_fail": "La salida de tu script no muestra el 'shape' correcto de los datos."
       },

--- a/backend/missions_contracts.yaml
+++ b/backend/missions_contracts.yaml
@@ -34,6 +34,8 @@ m3:
   script_path: "scripts/m3_explorer.py"
   feedback_script_missing: "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}."
   feedback_required_file_missing: "Falta el archivo necesario {required_path} para ejecutar la validación ({source})."
+  required_files:
+    - "sources/orders_seed.csv"
   deliverables:
     - type: file_exists
       path: "docs/m3_csv_notes.md"

--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -50,3 +50,25 @@ def test_verify_script_uses_custom_message_when_dependency_missing() -> None:
     assert feedback == [
         "Hace falta data/input.csv para ejecutar el script (repo/main en data/input.csv)."
     ]
+
+
+def test_verify_script_runs_with_required_files(tmp_path) -> None:
+    script_code = (
+        "from pathlib import Path\n"
+        "print(Path('sources/orders_seed.csv').read_text(encoding='utf-8').splitlines()[0])\n"
+    )
+    files = _DummyFiles(
+        {
+            "scripts/m3_explorer.py": script_code.encode(),
+            "sources/orders_seed.csv": b"order_id,customer_id\n1,C001\n",
+        }
+    )
+    contract = {
+        "script_path": "scripts/m3_explorer.py",
+        "required_files": ["sources/orders_seed.csv"],
+    }
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is True
+    assert feedback == []

--- a/sources/orders_seed.csv
+++ b/sources/orders_seed.csv
@@ -1,0 +1,4 @@
+order_id,customer_id,product_id,order_date,status,quantity,unit_price
+1001,C001,P001,2024-01-05,Shipped,2,19.99
+1002,C002,P003,2024-01-06,Pending,1,49.50
+1003,C001,P002,2024-01-08,Cancelled,3,12.00


### PR DESCRIPTION
## Summary
- add a sample `orders_seed.csv` dataset under `sources`
- declare the CSV as a required file for the M3 script contract in YAML and JSON
- cover the dependency handling with a verify_script test that reads the required file

## Testing
- pytest backend/tests/test_verify_script.py::test_verify_script_runs_with_required_files

------
https://chatgpt.com/codex/tasks/task_e_68d8870863bc8331be2fdf752adf5eb1