### PR TITLE
Enhance mission m3 DataFrame verification

### DIFF
--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -117,14 +117,30 @@
     ],
     "validations": [
       {
-        "type": "output_contains",
-        "text": "Shape: ",
-        "feedback_fail": "La salida de tu script no incluye el resultado de llamar a df.shape (usa print(f\"Shape: {df.shape}\"))."
-      },
-      {
-        "type": "output_contains",
-        "text": "Columns:",
-        "feedback_fail": "La salida de tu script no muestra la lista de columnas obtenida con df.columns.tolist()."
+        "type": "dataframe_output",
+        "shape": [
+          3,
+          7
+        ],
+        "columns": [
+          "order_id",
+          "customer_id",
+          "product_id",
+          "order_date",
+          "status",
+          "quantity",
+          "unit_price"
+        ],
+        "head": "   order_id customer_id product_id  order_date     status  quantity  unit_price\n0      1001        C001       P001  2024-01-05    Shipped         2       19.99\n1      1002        C002       P003  2024-01-06    Pending         1       49.50\n2      1003        C001       P002  2024-01-08  Cancelled         3       12.00",
+        "dtypes": {
+          "order_id": "int64",
+          "customer_id": "object",
+          "product_id": "object",
+          "order_date": "object",
+          "status": "object",
+          "quantity": "int64",
+          "unit_price": "float64"
+        }
       }
     ],
     "display_html": "<section class=\"mission\">\n      <h2>Historia</h2>\n      <p>El pasillo conduce a una bodega con cofres etiquetados: orders, products, customers. “Estos cofres son CSV”, explica Byte. “Parecen listas, pero esconden tablas. Para leerlos sin perdernos, usaremos una lupa especial: pandas. Con pandas, los cofres se transforman en DataFrames.”</p>\n      <p>Byte coloca cuatro tarjetas: head, shape, dtypes, columns. “Son tus cuatro sentidos para reconocer un DataFrame. head te muestra el comienzo; shape te dice cuántas filas y columnas hay; dtypes revela los tipos; columns te presenta cada campo por su nombre. Si dominas estos cuatro, sabrás qué tienes delante antes de tocarlo.”</p>\n      <h2>¿Para qué sirve?</h2>\n      <p>Cargar y entender datos rápidamente: validar columnas, tipos, tamaño y primeras filas para detectar problemas temprano.</p>\n      <h2>Al final podrás…</h2>\n      <ul>\n        <li>Escribir un programa que lea un CSV real.</li>\n        <li>Imprimir número de columnas, nombres, head(5), shape y dtypes.</li>\n        <li>Guardar notas y un resumen técnico en docs.</li>\n      </ul>\n      <h2>Videos</h2>\n      <ul>\n        <li><a href=\"https://www.youtube.com/watch?v=WkVpnTgAQLU\" target=\"_blank\">Leer y escribir CSV con pandas</a></li>\n        <li><a href=\"https://www.youtube.com/watch?v=sKQW-oIneFM\" target=\"_blank\">Leer CSV con pandas (rápido)</a></li>\n        <li><a href=\"https://www.youtube.com/watch?v=w7fNwreUsIk\" target=\"_blank\">¿Qué es una librería en Python?</a></li>\n        <li><a href=\"https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.shape.html\" target=\"_blank\">DataFrame.shape (referencia oficial)</a></li>\n      </ul>\n      <h2>Investigación — Fichas</h2>\n      <p>Completa 4 fichas: librería, pip, pandas, DataFrame. Para cada ficha incluye:</p>\n      <ul>\n        <li>Definición</li>\n        <li>Ejemplo en este proyecto (¿qué harás con ello hoy?)</li>\n        <li>Error común</li>\n        <li>Fuente vista</li>\n      </ul>\n      <p>Además, añade un mini‑mapa: para qué sirve cada propiedad head/shape/dtypes/columns.</p>\n      <h2>Práctica — Contrato</h2>\n      <p><strong>Entrada:</strong> Usa la ruta relativa <code>sources/orders_seed.csv</code> disponible en el repositorio.</p>\n      <p><strong>Logro:</strong> programa que lee el CSV (si falla por codificación, reintenta con otra) y muestra/guarda lo pedido.</p>\n      <p><strong>Salidas:</strong></p>\n      <ul>\n        <li><code>docs/m3_csv_notes.md</code> (lista de columnas + 1 duda)</li>\n        <li><code>docs/m3_practice_output.txt</code> (resumen con head/shape/dtypes/columns y valores)</li>\n      </ul>\n      <h2>Parte aplicada (detallada)</h2>\n      <p><strong>Situación:</strong> en M4 necesitarás una preview (3 filas) antes de copiar a Bronze.</p>\n      <p><strong>Qué debes hacer hoy:</strong></p>\n      <ul>\n        <li>Deja tu programa parametrizable por ruta (que puedas cambiar el archivo sin alterar la lógica).</li>\n        <li>Asegura que si no existe el archivo o hay error de codificación, el programa explique el problema con un mensaje claro (no stacktrace crudo).</li>\n        <li>Anota en tus notas cómo probarás tu programa con otro CSV del proyecto (si existiera).</li>\n      </ul>\n      <p><strong>Meta de calidad:</strong> tu programa sirve como visor reutilizable.</p>\n      <h2>Entregables</h2>\n      <p>m3_csv_notes.md, m3_practice_output.txt, scripts/m3_explorer.py</p>\n      <h2>Verificación</h2>\n      <p>El script existe y la salida contiene shape y columnas.</p>\n      <h2>Micro‑quiz (5)</h2>\n      <ol>\n        <li>¿Qué es una librería?</li>\n        <li>¿Cómo se lee un CSV en pandas?</li>\n        <li>¿Para qué sirve DataFrame.head()?</li>\n        <li>¿Qué información da DataFrame.shape?</li>\n        <li>¿Cómo verificas los tipos de columna?</li>\n      </ol>\n      <h2>Checklist</h2>\n      <ul>\n        <li>Videos vistos</li>\n        <li>Fichas completadas</li>\n        <li>Script creado y probado</li>\n        <li>Notas documentadas</li>\n      </ul>\n      <h2>Rúbrica (10)</h2>\n      <ul>\n        <li>Fichas (3)</li>\n        <li>Práctica (4)</li>\n        <li>Evidencias (2)</li>\n        <li>Orden (1)</li>\n      </ul>\n      <h2>Errores comunes</h2>\n      <ul>\n        <li>No manejar errores de codificación</li>\n        <li>No revisar shape antes de procesar</li>\n      </ul>\n    </section>\n    <section class=\"verification\">\n      <button id=\"verifyBtn\">Verificar y Entregar Misión</button>\n      <div id=\"verifyResult\"></div>\n    </section>"

--- a/backend/missions_contracts.yaml
+++ b/backend/missions_contracts.yaml
@@ -55,12 +55,29 @@ m3:
       content: "df.columns.tolist()"
       feedback_fail: "Tu script debe listar las columnas usando df.columns.tolist()."
   validations:
-    - type: output_contains
-      text: "Shape: "
-      feedback_fail: "La salida de tu script no incluye el resultado de llamar a df.shape (usa print(f\"Shape: {df.shape}\"))."
-    - type: output_contains
-      text: "Columns:"
-      feedback_fail: "La salida de tu script no muestra la lista de columnas obtenida con df.columns.tolist()."
+    - type: dataframe_output
+      shape: [3, 7]
+      columns:
+        - order_id
+        - customer_id
+        - product_id
+        - order_date
+        - status
+        - quantity
+        - unit_price
+      head: |
+           order_id customer_id product_id  order_date     status  quantity  unit_price
+        0      1001        C001       P001  2024-01-05    Shipped         2       19.99
+        1      1002        C002       P003  2024-01-06    Pending         1       49.50
+        2      1003        C001       P002  2024-01-08  Cancelled         3       12.00
+      dtypes:
+        order_id: int64
+        customer_id: object
+        product_id: object
+        order_date: object
+        status: object
+        quantity: int64
+        unit_price: float64
 
 m4:
   verification_type: evidence

--- a/backend/tests/test_missions_api.py
+++ b/backend/tests/test_missions_api.py
@@ -459,10 +459,25 @@ def test_m3_contract_requires_dataframe_introspection():
     assert columns_requirement is not None, "Se debe exigir la llamada a df.columns.tolist() en el script"
 
     validations = mission.get("validations", [])
-    feedback_by_text = {v.get("text"): v.get("feedback_fail", "") for v in validations}
-    assert "df.shape" in feedback_by_text.get(
-        "Shape: ", ""
-    ), "El mensaje de feedback debe mencionar df.shape"
-    assert "df.columns.tolist()" in feedback_by_text.get(
-        "Columns:", ""
-    ), "El mensaje de feedback debe mencionar df.columns.tolist()"
+    dataframe_validation = next(
+        (v for v in validations if v.get("type") == "dataframe_output"),
+        None,
+    )
+
+    assert (
+        dataframe_validation is not None
+    ), "La misión m3 debe validar la salida completa del DataFrame"
+    assert dataframe_validation.get("shape") == [
+        3,
+        7,
+    ], "El contrato debe verificar la forma esperada del DataFrame"
+    assert dataframe_validation.get("columns") == [
+        "order_id",
+        "customer_id",
+        "product_id",
+        "order_date",
+        "status",
+        "quantity",
+        "unit_price",
+    ]
+    assert "order_id" in (dataframe_validation.get("dtypes") or {})

--- a/backend/tests/test_verify_mission_executes_script.py
+++ b/backend/tests/test_verify_mission_executes_script.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from backend import app as backend_app
 from backend.github_client import RepositoryInfo, RepositorySelection
 
@@ -34,7 +38,39 @@ class _DummyConnection:
         return _DummyCursor()
 
 
+def _dataframe_validation_contract():
+    return {
+        "type": "dataframe_output",
+        "shape": [3, 7],
+        "columns": [
+            "order_id",
+            "customer_id",
+            "product_id",
+            "order_date",
+            "status",
+            "quantity",
+            "unit_price",
+        ],
+        "head": (
+            "   order_id customer_id product_id  order_date     status  quantity  unit_price\n"
+            "0      1001        C001       P001  2024-01-05    Shipped         2       19.99\n"
+            "1      1002        C002       P003  2024-01-06    Pending         1       49.50\n"
+            "2      1003        C001       P002  2024-01-08  Cancelled         3       12.00"
+        ),
+        "dtypes": {
+            "order_id": "int64",
+            "customer_id": "object",
+            "product_id": "object",
+            "order_date": "object",
+            "status": "object",
+            "quantity": "int64",
+            "unit_price": "float64",
+        },
+    }
+
+
 def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
+    pytest.importorskip("pandas")
     backend_app.app.config["TESTING"] = True
 
     monkeypatch.setattr(backend_app, "init_db", lambda: None)
@@ -48,10 +84,8 @@ def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
     contract = {
         "verification_type": "script_output",
         "script_path": "scripts/m3_explorer.py",
-        "validations": [
-            {"type": "output_contains", "text": "Shape: "},
-            {"type": "output_contains", "text": "Columns:"},
-        ],
+        "required_files": ["sources/orders_seed.csv"],
+        "validations": [_dataframe_validation_contract()],
         "source": {
             "repository": "default",
             "default_branch": "main",
@@ -86,16 +120,29 @@ def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
     monkeypatch.setattr(backend_app, "determine_student_repositories", _dummy_determine_repos)
     monkeypatch.setattr(backend_app, "select_repository_for_contract", _dummy_select_repo)
 
-    script_bytes = b"""import pandas as pd\n\n\nif __name__ == \"__main__\":\n    df = pd.DataFrame({\"a\": [1, 2]})\n    print(f\"Shape: {df.shape}\")\n    print(\"Columns:\", ", ".join(df.columns))\n"""
+    script_bytes = (
+        "import pandas as pd\n"
+        "from pathlib import Path\n"
+        "\n"
+        "if __name__ == \"__main__\":\n"
+        "    df = pd.read_csv(Path('sources/orders_seed.csv'))\n"
+        "    print(f\"Shape: {df.shape}\")\n"
+        "    print('Columns:', df.columns.tolist())\n"
+        "    print('Head:')\n"
+        "    print(df.head().to_string())\n"
+        "    print('Dtypes:')\n"
+        "    print(df.dtypes)\n"
+    ).encode()
 
     class _DummyGitHubClient:
         def get_file_content(self, repository: str, path: str, ref: str | None) -> bytes:
             assert repository == "dummy/repo"
             assert ref == "main"
-            expected_path = "students/student/scripts/m3_explorer.py"
-            if path != expected_path:
-                raise AssertionError(f"Unexpected path requested: {path}")
-            return script_bytes
+            if path == "students/student/scripts/m3_explorer.py":
+                return script_bytes
+            if path == "students/student/sources/orders_seed.csv":
+                return Path("sources/orders_seed.csv").read_bytes()
+            raise AssertionError(f"Unexpected path requested: {path}")
 
     monkeypatch.setattr(
         backend_app.GitHubClient,
@@ -113,3 +160,96 @@ def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
     assert response.status_code == 200
     payload = response.get_json()
     assert payload == {"verified": True, "feedback": []}
+
+
+def test_verify_mission_reports_dataframe_summary_errors(monkeypatch):
+    contract = {
+        "verification_type": "script_output",
+        "script_path": "scripts/m3_explorer.py",
+        "required_files": ["sources/orders_seed.csv"],
+        "validations": [_dataframe_validation_contract()],
+        "source": {
+            "repository": "default",
+            "default_branch": "main",
+            "base_path": "students/{slug}",
+        },
+    }
+
+    backend_app.app.config["TESTING"] = True
+
+    monkeypatch.setattr(backend_app, "init_db", lambda: None)
+    monkeypatch.setattr(backend_app, "get_db_connection", lambda: _DummyConnection())
+    monkeypatch.setattr(
+        backend_app,
+        "validate_session",
+        lambda token, slug=None, require_admin=False: True,
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "_get_mission_by_id",
+        lambda mission_id: {"mission_id": mission_id, "content": contract},
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "_fetch_missions_from_db",
+        lambda mission_id=None: [],
+    )
+
+    def _dummy_determine_repos(slug: str, role: str | None = None):
+        return {
+            "default": RepositoryInfo(
+                key="default",
+                repository="dummy/repo",
+                default_branch="main",
+            )
+        }
+
+    def _dummy_select_repo(source, slug: str, repositories):
+        info = repositories["default"]
+        return RepositorySelection(info=info, branch="main", base_path=f"students/{slug}")
+
+    monkeypatch.setattr(backend_app, "determine_student_repositories", _dummy_determine_repos)
+    monkeypatch.setattr(backend_app, "select_repository_for_contract", _dummy_select_repo)
+
+    script_bytes = (
+        "def main():\n"
+        "    print('Shape: (1, 1)')\n"
+        "    print(\"Columns: ['fake']\")\n"
+        "    print('Head:')\n"
+        "    print('nada que ver')\n"
+        "    print('Dtypes:')\n"
+        "    print('dtype: object')\n"
+        "\n"
+        "if __name__ == '__main__':\n"
+        "    main()\n"
+    ).encode()
+
+    class _DummyGitHubClientFailure:
+        def get_file_content(self, repository: str, path: str, ref: str | None) -> bytes:
+            assert repository == "dummy/repo"
+            assert ref == "main"
+            if path == "students/student/scripts/m3_explorer.py":
+                return script_bytes
+            if path == "students/student/sources/orders_seed.csv":
+                return Path("sources/orders_seed.csv").read_bytes()
+            raise AssertionError(f"Unexpected path requested: {path}")
+
+    monkeypatch.setattr(
+        backend_app.GitHubClient,
+        "from_settings",
+        classmethod(lambda cls: _DummyGitHubClientFailure()),
+    )
+
+    client = backend_app.app.test_client()
+    response = client.post(
+        "/api/verify_mission",
+        json={"slug": "student", "mission_id": "m3"},
+        headers={"Authorization": "Bearer token"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["verified"] is False
+    joined_feedback = " ".join(payload.get("feedback", []))
+    assert "df.shape" in joined_feedback
+    assert "df.columns.tolist()" in joined_feedback


### PR DESCRIPTION
## Summary
- add a dataframe_output validation path in verify_script to compare DataFrame shape, columns, head, and dtypes with detailed feedback
- update the mission m3 contract definitions to require the full DataFrame summary instead of simple output_contains checks
- expand verify_script, mission execution, and missions API tests to cover the richer validation and error messaging

## Testing
- pytest backend/tests/test_verify_script.py backend/tests/test_verify_mission_executes_script.py backend/tests/test_missions_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d8a0e1b63c8331b1e592b13af956a0