### PR TITLE
Ensure M3 verification uses role-specific repositories

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3822,7 +3822,7 @@ def api_verify_mission():
         return jsonify({"verified": False, "feedback": [str(exc)]})
     try:
         selection = select_repository_for_contract(
-            contract.get("source"), slug, available_repos
+            contract.get("source"), slug, available_repos, role=role
         )
     except GitHubConfigurationError as exc:
         print(f"Contract repository selection error: {exc}", file=sys.stderr)

--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -78,7 +78,8 @@
     "source": {
       "repository": "default",
       "default_branch": "main",
-      "base_path": "students/{slug}"
+      "base_path": "students/{slug}",
+      "prefer_repository_by_role": true
     },
     "deliverables": [
       {

--- a/backend/missions_contracts.yaml
+++ b/backend/missions_contracts.yaml
@@ -31,6 +31,11 @@ m2:
 
 m3:
   verification_type: script_output
+  source:
+    repository: default
+    default_branch: main
+    base_path: "students/{slug}"
+    prefer_repository_by_role: true
   script_path: "scripts/m3_explorer.py"
   feedback_script_missing: "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}."
   feedback_required_file_missing: "Falta el archivo necesario {required_path} (debe existir en students/{{slug}}/sources/orders_seed.csv). Sigue la guía docs/orders_seed_instructions.md antes de validar ({source})."

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -43,3 +43,31 @@ def test_select_repository_for_contract_strips_branch_overrides(monkeypatch):
         repositories=repositories,
     )
     assert selection.branch == "main"
+
+
+def test_select_repository_for_contract_prefers_role_when_enabled():
+    repositories = {
+        "ventas": github_client.RepositoryInfo(
+            key="ventas", repository="org/ventas", default_branch="main"
+        ),
+        "operaciones": github_client.RepositoryInfo(
+            key="operaciones", repository="org/operaciones", default_branch="main"
+        ),
+    }
+
+    selection = github_client.select_repository_for_contract(
+        {"repository": "default", "prefer_repository_by_role": True},
+        slug="student",  # slug without hints should fall back to role
+        repositories=repositories,
+        role="Operaciones",
+    )
+
+    assert selection.info.key == "operaciones"
+
+    selection_from_slug = github_client.select_repository_for_contract(
+        {"repository": "default", "prefer_repository_by_role": True},
+        slug="aprendiz-v",  # sufijo -v coincide con repositorio de ventas
+        repositories=repositories,
+    )
+
+    assert selection_from_slug.info.key == "ventas"

--- a/backend/tests/test_verify_mission_executes_script.py
+++ b/backend/tests/test_verify_mission_executes_script.py
@@ -113,7 +113,7 @@ def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
             )
         }
 
-    def _dummy_select_repo(source, slug: str, repositories):
+    def _dummy_select_repo(source, slug: str, repositories, role=None):
         info = repositories["default"]
         return RepositorySelection(info=info, branch="main", base_path=f"students/{slug}")
 
@@ -204,7 +204,7 @@ def test_verify_mission_reports_dataframe_summary_errors(monkeypatch):
             )
         }
 
-    def _dummy_select_repo(source, slug: str, repositories):
+    def _dummy_select_repo(source, slug: str, repositories, role=None):
         info = repositories["default"]
         return RepositorySelection(info=info, branch="main", base_path=f"students/{slug}")
 


### PR DESCRIPTION
## Summary
- allow repository selection to prefer the student's role or slug when contracts opt in
- enable the M3 contract to request role-aware repository selection for required files
- extend tests to cover the new selection behavior and updated function signature

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d89db8bbb88331a33965898173275a