### PR TITLE
Support df-prefixed dataframe summaries

### DIFF
--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -201,3 +201,67 @@ def test_verify_script_accepts_valid_dataframe_summary() -> None:
 
     assert passed is True
     assert feedback == []
+
+
+def test_verify_script_accepts_dataframe_summary_with_df_prefix_format() -> None:
+    script_code = (
+        "def main():\n"
+        "    print('df.shape = (3, 7)')\n"
+        "    print(\"df.columns.tolist(): ['order_id', 'customer_id', 'product_id', 'order_date', 'status', 'quantity', 'unit_price']\")\n"
+        "    print('df.head() ->')\n"
+        "    print('   order_id customer_id product_id  order_date     status  quantity  unit_price')\n"
+        "    print('0      1001        C001       P001  2024-01-05    Shipped         2       19.99')\n"
+        "    print('1      1002        C002       P003  2024-01-06    Pending         1       49.50')\n"
+        "    print('2      1003        C001       P002  2024-01-08  Cancelled         3       12.00')\n"
+        "    print('df.dtypes =')\n"
+        "    print('order_id int64')\n"
+        "    print('customer_id object')\n"
+        "    print('product_id object')\n"
+        "    print('order_date object')\n"
+        "    print('status object')\n"
+        "    print('quantity int64')\n"
+        "    print('unit_price float64')\n"
+        "\n"
+        "if __name__ == '__main__':\n"
+        "    main()\n"
+    )
+
+    files = _DummyFiles({"scripts/m3_explorer.py": script_code.encode()})
+    contract = {
+        "script_path": "scripts/m3_explorer.py",
+        "validations": [
+            {
+                "type": "dataframe_output",
+                "shape": [3, 7],
+                "columns": [
+                    "order_id",
+                    "customer_id",
+                    "product_id",
+                    "order_date",
+                    "status",
+                    "quantity",
+                    "unit_price",
+                ],
+                "head": (
+                    "   order_id customer_id product_id  order_date     status  quantity  unit_price\n"
+                    "0      1001        C001       P001  2024-01-05    Shipped         2       19.99\n"
+                    "1      1002        C002       P003  2024-01-06    Pending         1       49.50\n"
+                    "2      1003        C001       P002  2024-01-08  Cancelled         3       12.00"
+                ),
+                "dtypes": {
+                    "order_id": "int64",
+                    "customer_id": "object",
+                    "product_id": "object",
+                    "order_date": "object",
+                    "status": "object",
+                    "quantity": "int64",
+                    "unit_price": "float64",
+                },
+            }
+        ],
+    }
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is True
+    assert feedback == []


### PR DESCRIPTION
## Summary
- normalize dataframe summary lines that start with df.* so they map to the existing parser labels
- ensure parsed summaries populate the same fields and add a regression test covering df.* formatted output

## Testing
- pytest backend/tests/test_verify_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d94dc7f9f883318a5f6e643f7c26ed