### PR TITLE
Normalize dataframe verification output parsing

### DIFF
--- a/backend/tests/test_verify_mission_executes_script.py
+++ b/backend/tests/test_verify_mission_executes_script.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import werkzeug
 
 from backend import app as backend_app
 from backend.github_client import RepositoryInfo, RepositorySelection
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "0"
 
 
 class _DummyCursor:
@@ -126,12 +131,10 @@ def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
         "\n"
         "if __name__ == \"__main__\":\n"
         "    df = pd.read_csv(Path('sources/orders_seed.csv'))\n"
-        "    print(f\"Shape: {df.shape}\")\n"
-        "    print('Columns:', df.columns.tolist())\n"
-        "    print('Head:')\n"
-        "    print(df.head().to_string())\n"
-        "    print('Dtypes:')\n"
-        "    print(df.dtypes)\n"
+        "    print('Shape =', df.shape)\n"
+        "    print('Columns =', df.columns.tolist())\n"
+        "    print('Head:', df.head())\n"
+        "    print('Dtypes:', df.dtypes)\n"
     ).encode()
 
     class _DummyGitHubClient:

--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -265,3 +265,68 @@ def test_verify_script_accepts_dataframe_summary_with_df_prefix_format() -> None
 
     assert passed is True
     assert feedback == []
+
+
+def test_verify_script_accepts_dataframe_summary_with_label_variations() -> None:
+    pytest.importorskip("pandas")
+
+    script_code = (
+        "import pandas as pd\n"
+        "from pathlib import Path\n"
+        "\n"
+        "def main():\n"
+        "    df = pd.read_csv(Path('sources/orders_seed.csv'))\n"
+        "    print('Shape =', df.shape)\n"
+        "    print('Columns =', df.columns.tolist())\n"
+        "    print('Head:', df.head())\n"
+        "    print('Dtypes:', df.dtypes)\n"
+        "\n"
+        "if __name__ == '__main__':\n"
+        "    main()\n"
+    )
+
+    files = _DummyFiles(
+        {
+            "scripts/m3_explorer.py": script_code.encode(),
+            "sources/orders_seed.csv": Path('sources/orders_seed.csv').read_bytes(),
+        }
+    )
+    contract = {
+        "script_path": "scripts/m3_explorer.py",
+        "required_files": ["sources/orders_seed.csv"],
+        "validations": [
+            {
+                "type": "dataframe_output",
+                "shape": [3, 7],
+                "columns": [
+                    "order_id",
+                    "customer_id",
+                    "product_id",
+                    "order_date",
+                    "status",
+                    "quantity",
+                    "unit_price",
+                ],
+                "head": (
+                    "   order_id customer_id product_id  order_date     status  quantity  unit_price\n"
+                    "0      1001        C001       P001  2024-01-05    Shipped         2       19.99\n"
+                    "1      1002        C002       P003  2024-01-06    Pending         1       49.50\n"
+                    "2      1003        C001       P002  2024-01-08  Cancelled         3       12.00"
+                ),
+                "dtypes": {
+                    "order_id": "int64",
+                    "customer_id": "object",
+                    "product_id": "object",
+                    "order_date": "object",
+                    "status": "object",
+                    "quantity": "int64",
+                    "unit_price": "float64",
+                },
+            }
+        ],
+    }
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is True
+    assert feedback == []


### PR DESCRIPTION
## Summary
- expand dataframe output parsing to normalize direct Shape/Columns/Head/Dtypes labels and keep inline content
- add coverage for scripts that emit Shape/Columns/Head/Dtypes using alternative separators in verify_script and mission execution tests

## Testing
- pytest backend/tests/test_verify_script.py
- pytest backend/tests/test_verify_mission_executes_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d95529f98083319e5c3199da8a5907