### PR TITLE
Handle script runtime failures with detailed feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Los repositorios asignados por rol continúan definiéndose mediante variables d
 
 El backend identifica qué repositorio debe revisar cada estudiante usando su `slug` o el `role` registrado (`ventas`, `operaciones`, sufijos `_v`/`_o`, etc.). En `backend/missions_contracts.json` cada misión incluye una sección `source` con la plantilla de ruta base (`students/{slug}`) y el repositorio objetivo (`default`, `ventas` u `operaciones`). Durante la verificación se descargan únicamente los archivos declarados en el contrato y, en el caso de scripts, se copian a un directorio temporal antes de ejecutarlos.
 
-Si GitHub devuelve un error o el archivo solicitado no existe, la API responde con `verified: false` y un mensaje de retroalimentación indicando qué archivo falló y en qué repositorio se buscó. Esto permite que el estudiante ajuste su entrega sin necesidad de revisar los logs del servidor.
+Si GitHub devuelve un error o el archivo solicitado no existe, la API responde con `verified: false` y un mensaje de retroalimentación indicando qué archivo falló y en qué repositorio se buscó. Esto permite que el estudiante ajuste su entrega sin necesidad de revisar los logs del servidor. Cuando el script se ejecuta pero termina con errores (por ejemplo, por un `ModuleNotFoundError`), la retroalimentación ahora incluye el código de salida y el traceback completo capturado para que la persona estudiante pueda diagnosticarlo sin salir del panel.
 
 ## Evaluación automática con modelos de lenguaje
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -2522,7 +2522,7 @@ def verify_script(files: RepositoryFileAccessor, contract: dict) -> Tuple[bool, 
             result = subprocess.run(
                 [sys.executable, str(local_script_path)],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=subprocess.PIPE,
                 text=True,
                 cwd=tmpdir,
                 timeout=30,
@@ -2530,6 +2530,20 @@ def verify_script(files: RepositoryFileAccessor, contract: dict) -> Tuple[bool, 
             output = result.stdout or ""
         except Exception as exc:  # pragma: no cover - defensive
             return False, [f"Error running script: {exc}"]
+
+        if result.returncode != 0:
+            stdout_text = (result.stdout or "").strip()
+            stderr_text = (result.stderr or "").strip()
+            failure_details = [
+                f"STDOUT:\n{stdout_text}" if stdout_text else "STDOUT: (sin salida)",
+                f"STDERR:\n{stderr_text}" if stderr_text else "STDERR: (sin salida)",
+            ]
+            message = (
+                "La ejecución del script terminó con errores. "
+                f"Código de salida: {result.returncode}.\n"
+                + "\n".join(failure_details)
+            )
+            return False, [message]
 
     def _parse_dataframe_output(text: str) -> Dict[str, object]:
         normalized = text.replace("\r\n", "\n").replace("\r", "\n")

--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -78,6 +78,20 @@ def test_verify_script_runs_with_required_files(tmp_path) -> None:
     assert feedback == []
 
 
+def test_verify_script_reports_script_exception() -> None:
+    script_code = "import nonexistent_module\n"
+    files = _DummyFiles({"scripts/m3_explorer.py": script_code.encode()})
+    contract = {"script_path": "scripts/m3_explorer.py"}
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is False
+    assert len(feedback) == 1
+    message = feedback[0]
+    assert "Código de salida" in message
+    assert "ModuleNotFoundError" in message
+
+
 def test_verify_script_reports_dataframe_summary_mismatch() -> None:
     script_code = (
         "def main():\n"


### PR DESCRIPTION
## Summary
- detect non-zero exit codes when running student scripts and return the captured stdout/stderr in the feedback
- add regression tests that assert exceptions raised by the script are surfaced to the learner
- document that failing scripts now show the real traceback in the panel feedback

## Testing
- pytest backend/tests/test_verify_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d95a7caf048331a996a4d29bad9ef3