### PR TITLE
Add workspace materialization for mission scripts

### DIFF
--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -111,6 +111,9 @@
       }
     ],
     "script_path": "scripts/m3_explorer.py",
+    "workspace_paths": [
+      "scripts/"
+    ],
     "feedback_script_missing": "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}.",
     "feedback_required_file_missing": "Falta el archivo necesario {required_path} (debe existir en students/{{slug}}/sources/orders_seed.csv). Sigue la guía docs/orders_seed_instructions.md antes de validar ({source}).",
     "required_files": [


### PR DESCRIPTION
## Summary
- add `workspace_paths` to the M3 contract so auxiliary modules are copied before verification
- implement GitHub workspace materialization and hook it into `verify_script`
- extend unit tests to cover scripts importing helpers from the workspace

## Testing
- pytest backend/tests/test_verify_script.py backend/tests/test_verify_mission_executes_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d982633ab883318151125100372948