### PR TITLE
Add sources directory to M3 verification workspace

### DIFF
--- a/backend/missions_contracts.json
+++ b/backend/missions_contracts.json
@@ -112,7 +112,8 @@
     ],
     "script_path": "scripts/m3_explorer.py",
     "workspace_paths": [
-      "scripts/"
+      "scripts/",
+      "sources/"
     ],
     "feedback_script_missing": "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}.",
     "feedback_required_file_missing": "Falta el archivo necesario {required_path} (debe existir en students/{{slug}}/sources/orders_seed.csv). Sigue la guía docs/orders_seed_instructions.md antes de validar ({source}).",

--- a/backend/tests/test_verify_mission_executes_script.py
+++ b/backend/tests/test_verify_mission_executes_script.py
@@ -90,7 +90,7 @@ def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
         "verification_type": "script_output",
         "script_path": "scripts/m3_explorer.py",
         "required_files": ["sources/orders_seed.csv"],
-        "workspace_paths": ["scripts/"],
+        "workspace_paths": ["scripts/", "sources/"],
         "validations": [_dataframe_validation_contract()],
         "source": {
             "repository": "default",
@@ -160,6 +160,12 @@ def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
                     target = root / "scripts"
                     target.mkdir(parents=True, exist_ok=True)
                     (target / "helpers.py").write_bytes(helper_bytes)
+                elif cleaned == "sources":
+                    target = root / "sources"
+                    target.mkdir(parents=True, exist_ok=True)
+                    (target / "orders_seed.csv").write_bytes(
+                        Path("sources/orders_seed.csv").read_bytes()
+                    )
 
     monkeypatch.setattr(
         backend_app.GitHubClient,
@@ -184,7 +190,7 @@ def test_verify_mission_reports_dataframe_summary_errors(monkeypatch):
         "verification_type": "script_output",
         "script_path": "scripts/m3_explorer.py",
         "required_files": ["sources/orders_seed.csv"],
-        "workspace_paths": ["scripts/"],
+        "workspace_paths": ["scripts/", "sources/"],
         "validations": [_dataframe_validation_contract()],
         "source": {
             "repository": "default",

--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -105,7 +105,7 @@ def test_verify_script_runs_with_required_files(tmp_path) -> None:
     contract = {
         "script_path": "scripts/m3_explorer.py",
         "required_files": ["sources/orders_seed.csv"],
-        "workspace_paths": ["scripts/"],
+        "workspace_paths": ["scripts/", "sources/"],
     }
 
     passed, feedback = backend_app.verify_script(files, contract)
@@ -220,7 +220,7 @@ def test_verify_script_accepts_valid_dataframe_summary() -> None:
     contract = {
         "script_path": "scripts/m3_explorer.py",
         "required_files": ["sources/orders_seed.csv"],
-        "workspace_paths": ["scripts/"],
+        "workspace_paths": ["scripts/", "sources/"],
         "validations": [
             {
                 "type": "dataframe_output",


### PR DESCRIPTION
## Summary
- include the sources directory in the M3 mission contract workspace paths
- update verification tests to expect both scripts/ and sources/ and to provision the CSV from the workspace download

## Testing
- pytest backend/tests/test_verify_script.py backend/tests/test_verify_mission_executes_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d98de0536083318bd03f8f270a1f21