### PR TITLE
Enhance mission repository selection using mission roles

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3888,7 +3888,12 @@ def api_verify_mission():
         return jsonify(
             {"verified": False, "feedback": [f"No se encontró contrato para {mission_id}"]}
         )
-    contract = mission_record.get("content") if isinstance(mission_record, Mapping) else None
+    mission_roles = None
+    if isinstance(mission_record, Mapping):
+        mission_roles = mission_record.get("roles")
+        contract = mission_record.get("content")
+    else:
+        contract = None
     if not contract:
         return jsonify(
             {"verified": False, "feedback": [f"No se encontró contrato para {mission_id}"]}
@@ -3905,7 +3910,11 @@ def api_verify_mission():
         return jsonify({"verified": False, "feedback": [str(exc)]})
     try:
         selection = select_repository_for_contract(
-            contract.get("source"), slug, available_repos, role=role
+            contract.get("source"),
+            slug,
+            available_repos,
+            role=role,
+            mission_roles=mission_roles,
         )
     except GitHubConfigurationError as exc:
         print(f"Contract repository selection error: {exc}", file=sys.stderr)

--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -374,6 +374,7 @@ def select_repository_for_contract(
     repositories: Dict[str, RepositoryInfo],
     *,
     role: str | None = None,
+    mission_roles: Iterable[str] | None = None,
 ) -> RepositorySelection:
     source = source_config or {}
     requested_value = source.get("repository") or "default"
@@ -382,6 +383,13 @@ def select_repository_for_contract(
 
     role_lower = (role or "").strip().lower()
     slug_lower = (slug or "").strip().lower()
+
+    if isinstance(mission_roles, str):
+        mission_role_values: Iterable[str] = [mission_roles]
+    elif mission_roles is None:
+        mission_role_values = []
+    else:
+        mission_role_values = mission_roles
 
     def _match_repository_from_value(value: str) -> str | None:
         if not value:
@@ -396,6 +404,12 @@ def select_repository_for_contract(
         matched_key = _match_repository_from_value(role_lower)
         if matched_key is None:
             matched_key = _match_repository_from_value(slug_lower)
+        if matched_key is None:
+            for mission_role in mission_role_values:
+                normalized = str(mission_role or "").strip().lower()
+                matched_key = _match_repository_from_value(normalized)
+                if matched_key:
+                    break
         if matched_key:
             requested_key = matched_key
 

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -71,3 +71,24 @@ def test_select_repository_for_contract_prefers_role_when_enabled():
     )
 
     assert selection_from_slug.info.key == "ventas"
+
+
+def test_select_repository_for_contract_falls_back_to_mission_roles():
+    repositories = {
+        "ventas": github_client.RepositoryInfo(
+            key="ventas", repository="org/ventas", default_branch="main"
+        ),
+        "operaciones": github_client.RepositoryInfo(
+            key="operaciones", repository="org/operaciones", default_branch="main"
+        ),
+    }
+
+    selection = github_client.select_repository_for_contract(
+        {"repository": "default", "prefer_repository_by_role": True},
+        slug="estudiante",  # sin sufijo especial
+        repositories=repositories,
+        role="",  # sin rol almacenado
+        mission_roles=["Operaciones"],
+    )
+
+    assert selection.info.key == "operaciones"


### PR DESCRIPTION
## Summary
- capture mission roles during mission verification and forward them to repository selection
- allow repository selection to consider mission-level roles when preferring repositories by role
- add unit test ensuring mission roles drive the Operaciones repository choice when student metadata lacks a role

## Testing
- pytest backend/tests/test_github_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d99674f49c8331ab3d8fb07eb7b8a6