### PR TITLE
Add workspace paths to mission 3 contract and guard regression

### DIFF
--- a/backend/missions_contracts.yaml
+++ b/backend/missions_contracts.yaml
@@ -37,6 +37,9 @@ m3:
     base_path: "students/{slug}"
     prefer_repository_by_role: true
   script_path: "scripts/m3_explorer.py"
+  workspace_paths:
+    - "scripts/"
+    - "sources/"
   feedback_script_missing: "No encontré tu script principal de la misión 3 ({script_path}). Revisa que exista en {source}."
   feedback_required_file_missing: "Falta el archivo necesario {required_path} (debe existir en students/{{slug}}/sources/orders_seed.csv). Sigue la guía docs/orders_seed_instructions.md antes de validar ({source})."
   required_files:

--- a/backend/tests/test_missions_api.py
+++ b/backend/tests/test_missions_api.py
@@ -110,6 +110,9 @@ def test_m3_contract_includes_orders_seed_guidance(sqlite_backend):
     contracts = backend_app.load_contracts()
     m3 = contracts.get("m3")
     assert isinstance(m3, dict)
+    workspace_paths = m3.get("workspace_paths")
+    assert isinstance(workspace_paths, list), "La misión m3 debe exponer rutas de workspace"
+    assert "sources/" in workspace_paths, "Se espera que m3 incluya sources/ en workspace_paths"
     feedback_message = m3.get("feedback_required_file_missing", "")
     assert "students/{{slug}}/sources/orders_seed.csv" in feedback_message
     assert "docs/orders_seed_instructions.md" in feedback_message


### PR DESCRIPTION
## Summary
- include both scripts/ and sources/ workspace paths in the mission 3 YAML contract so verify_script can pull required files
- extend the mission contract sync test to assert that mission 3 keeps sources/ in its workspace_paths list

## Testing
- pytest backend/tests/test_missions_api.py::test_m3_contract_includes_orders_seed_guidance


------
https://chatgpt.com/codex/tasks/task_e_68d99aa27438833198796a40d9550e62