### PR TITLE
Handle mission verification fallback between Ventas and Operaciones repos

### DIFF
--- a/backend/tests/test_verify_mission_executes_script.py
+++ b/backend/tests/test_verify_mission_executes_script.py
@@ -119,7 +119,9 @@ def test_verify_mission_executes_m3_script_with_pandas(monkeypatch):
             )
         }
 
-    def _dummy_select_repo(source, slug: str, repositories, role=None):
+    def _dummy_select_repo(
+        source, slug: str, repositories, role=None, preferred_repository_key=None
+    ):
         info = repositories["default"]
         return RepositorySelection(info=info, branch="main", base_path=f"students/{slug}")
 
@@ -228,7 +230,9 @@ def test_verify_mission_reports_dataframe_summary_errors(monkeypatch):
             )
         }
 
-    def _dummy_select_repo(source, slug: str, repositories, role=None):
+    def _dummy_select_repo(
+        source, slug: str, repositories, role=None, preferred_repository_key=None
+    ):
         info = repositories["default"]
         return RepositorySelection(info=info, branch="main", base_path=f"students/{slug}")
 


### PR DESCRIPTION
## Summary
- allow select_repository_for_contract to accept an explicit preferred repository key for overrides
- retry script verifications in api_verify_mission using mission role candidates when prefer_repository_by_role cannot resolve a repo
- add a regression test that exercises fallback from Ventas to Operaciones when required files are missing

## Testing
- pytest backend/tests/test_github_client.py backend/tests/test_missions_api.py::test_verify_mission_prefers_operaciones_when_ventas_missing_files

------
https://chatgpt.com/codex/tasks/task_e_68d99e65a8e08331a60ea49b692b49a9