### PR TITLE
Handle repository base paths during script verification

### DIFF
--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -486,6 +486,10 @@ class RepositoryFileAccessor:
     def branch(self) -> str:
         return self._selection.branch
 
+    @property
+    def base_path(self) -> str:
+        return self._selection.base_path
+
     def describe_source(self, relative_path: str | None = None) -> str:
         base = f"{self.repository} (rama {self.branch})"
         if relative_path is None:


### PR DESCRIPTION
## Summary
- expose the repository selection base path on `RepositoryFileAccessor`
- stage script verification assets inside the repository base directory and execute from there
- add coverage to ensure scripts can open files under `students/{slug}`

## Testing
- pytest backend/tests/test_verify_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a28454c08331aa7f1fe56474af7b