### PR TITLE
Ensure orders_seed.csv is materialized for script verification

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2533,10 +2533,10 @@ def verify_script(files: RepositoryFileAccessor, contract: dict) -> Tuple[bool, 
         except ValueError as exc:
             return False, [f"Ruta de script inválida {script_path}: {exc}"]
 
-        for dependency in required_files:
-            dep_path = (dependency or "").strip()
+        def _ensure_required_file(path: str) -> Optional[List[str]]:
+            dep_path = (path or "").strip()
             if not dep_path:
-                continue
+                return None
             try:
                 dep_bytes = files.read_bytes(dep_path)
             except GitHubFileNotFoundError:
@@ -2554,13 +2554,26 @@ def verify_script(files: RepositoryFileAccessor, contract: dict) -> Tuple[bool, 
                         f"No se encontró el archivo requerido {dep_path} "
                         f"({dep_source})."
                     )
-                return False, [message]
+                return [message]
             except GitHubDownloadError as exc:
-                return False, [f"No se pudo descargar {dep_path}: {exc}"]
+                return [f"No se pudo descargar {dep_path}: {exc}"]
             try:
                 _write_file(execution_root, dep_path, dep_bytes)
             except ValueError as exc:
-                return False, [f"Ruta inválida {dep_path}: {exc}"]
+                return [f"Ruta inválida {dep_path}: {exc}"]
+            return None
+
+        for dependency in required_files:
+            error_messages = _ensure_required_file(dependency)
+            if error_messages:
+                return False, error_messages
+
+        orders_seed_relative = "sources/orders_seed.csv"
+        orders_seed_path = execution_root / orders_seed_relative
+        if not orders_seed_path.exists():
+            error_messages = _ensure_required_file(orders_seed_relative)
+            if error_messages:
+                return False, error_messages
 
         try:
             result = subprocess.run(

--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -121,6 +121,34 @@ def test_verify_script_runs_with_required_files(tmp_path) -> None:
     assert feedback == []
 
 
+def test_verify_script_materializes_orders_seed_when_missing_from_required_files() -> None:
+    script_code = (
+        "from pathlib import Path\n"
+        "\n"
+        "def main():\n"
+        "    csv_path = Path('sources/orders_seed.csv')\n"
+        "    print(csv_path.read_text(encoding='utf-8').splitlines()[0])\n"
+        "\n"
+        "if __name__ == '__main__':\n"
+        "    main()\n"
+    )
+    files = _DummyFiles(
+        {
+            "scripts/m3_explorer.py": script_code.encode(),
+            "sources/orders_seed.csv": b"order_id,customer_id\n1,C001\n",
+        }
+    )
+    contract = {
+        "script_path": "scripts/m3_explorer.py",
+        "workspace_paths": ["scripts/"],
+    }
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is True
+    assert feedback == []
+
+
 def test_verify_script_honors_base_path_when_accessing_files() -> None:
     script_code = (
         "from pathlib import Path\n"
@@ -153,7 +181,12 @@ def test_verify_script_honors_base_path_when_accessing_files() -> None:
 
 def test_verify_script_reports_script_exception() -> None:
     script_code = "import nonexistent_module\n"
-    files = _DummyFiles({"scripts/m3_explorer.py": script_code.encode()})
+    files = _DummyFiles(
+        {
+            "scripts/m3_explorer.py": script_code.encode(),
+            "sources/orders_seed.csv": b"order_id,customer_id\n1,C001\n",
+        }
+    )
     contract = {"script_path": "scripts/m3_explorer.py"}
 
     passed, feedback = backend_app.verify_script(files, contract)
@@ -180,7 +213,12 @@ def test_verify_script_reports_dataframe_summary_mismatch() -> None:
         "if __name__ == '__main__':\n"
         "    main()\n"
     )
-    files = _DummyFiles({"scripts/m3_explorer.py": script_code.encode()})
+    files = _DummyFiles(
+        {
+            "scripts/m3_explorer.py": script_code.encode(),
+            "sources/orders_seed.csv": b"order_id,customer_id\n1,C001\n",
+        }
+    )
     contract = {
         "script_path": "scripts/m3_explorer.py",
         "validations": [
@@ -319,7 +357,12 @@ def test_verify_script_accepts_dataframe_summary_with_df_prefix_format() -> None
         "    main()\n"
     )
 
-    files = _DummyFiles({"scripts/m3_explorer.py": script_code.encode()})
+    files = _DummyFiles(
+        {
+            "scripts/m3_explorer.py": script_code.encode(),
+            "sources/orders_seed.csv": b"order_id,customer_id\n1,C001\n",
+        }
+    )
     contract = {
         "script_path": "scripts/m3_explorer.py",
         "validations": [


### PR DESCRIPTION
## Summary
- ensure verify_script writes required files through a shared helper and backfills sources/orders_seed.csv when absent
- return the existing friendly feedback if the CSV cannot be fetched
- add regression coverage to confirm scripts run successfully without declaring the CSV in required_files

## Testing
- pytest backend/tests/test_verify_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d9cd8578e88331bd3bbcb4bb08da60