### PR TITLE
Support parent directory access for verify_script dependencies

### DIFF
--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -151,6 +151,35 @@ def test_verify_script_honors_base_path_when_accessing_files() -> None:
     assert feedback == []
 
 
+def test_verify_script_allows_parent_directory_access() -> None:
+    script_code = (
+        "from pathlib import Path\n"
+        "\n"
+        "def main():\n"
+        "    csv_path = Path('../sources/orders_seed.csv')\n"
+        "    print(csv_path.read_text(encoding='utf-8').splitlines()[0])\n"
+        "\n"
+        "if __name__ == '__main__':\n"
+        "    main()\n"
+    )
+    files = _DummyFiles(
+        {
+            "scripts/m3_explorer.py": script_code.encode(),
+            "sources/orders_seed.csv": b"order_id,customer_id\n1,C001\n",
+        },
+        base_path="students/student",
+    )
+    contract = {
+        "script_path": "scripts/m3_explorer.py",
+        "required_files": ["sources/orders_seed.csv"],
+    }
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is True
+    assert feedback == []
+
+
 def test_verify_script_reports_script_exception() -> None:
     script_code = "import nonexistent_module\n"
     files = _DummyFiles({"scripts/m3_explorer.py": script_code.encode()})


### PR DESCRIPTION
## Summary
- ensure `verify_script` replicates required files into base path ancestor directories created for the execution root
- add a regression test covering scripts that access `../sources/...` when a base path is configured

## Testing
- pytest backend/tests/test_verify_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d9d3cfe3f48331a68529ec8421ea1f