### PR TITLE
Handle prefixed dependencies without base path

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2612,6 +2612,13 @@ def verify_script(files: RepositoryFileAccessor, contract: dict) -> Tuple[bool, 
             alias_prefixes = []
             if normalized_base_prefix:
                 alias_prefixes.append(normalized_base_prefix)
+            else:
+                dependency_parent = normalized_dep.parent
+                while dependency_parent and dependency_parent != PurePosixPath("."):
+                    parent_prefix = dependency_parent.as_posix()
+                    if parent_prefix:
+                        alias_prefixes.append(parent_prefix)
+                    dependency_parent = dependency_parent.parent
             alias_prefixes.extend(script_prefix_candidates)
             unique_alias_prefixes = sorted({prefix for prefix in alias_prefixes if prefix}, key=len, reverse=True)
             for prefix in unique_alias_prefixes:


### PR DESCRIPTION
## Summary
- extend dependency aliasing in the script verifier to consider parent prefixes when no base path is configured
- add regression coverage ensuring prefixed required files are accessible when the script lives outside the student directory

## Testing
- pytest backend/tests/test_verify_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d9ed85459483318628443ca3a47d50