### PR TITLE
Improve workspace alias fallbacks

### DIFF
--- a/backend/tests/test_verify_script.py
+++ b/backend/tests/test_verify_script.py
@@ -193,6 +193,29 @@ def test_verify_script_attempts_workspace_aliases_without_base_path() -> None:
     ]
 
 
+def test_verify_script_attempts_parent_alias_without_base_path() -> None:
+    script_code = "print('ok')\n"
+    files = _DummyFiles(
+        {
+            "scripts/m3_explorer.py": script_code.encode(),
+            "sources/orders_seed.csv": b"order_id\n1\n",
+        }
+    )
+    contract = {
+        "script_path": "scripts/m3_explorer.py",
+        "workspace_paths": ["students/student/sources/"],
+    }
+
+    passed, feedback = backend_app.verify_script(files, contract)
+
+    assert passed is True
+    assert feedback == []
+    assert files.workspace_calls == [
+        ["students/student/sources/"],
+        ["sources/"],
+    ]
+
+
 def test_verify_script_allows_parent_directory_access() -> None:
     script_code = (
         "from pathlib import Path\n"


### PR DESCRIPTION
## Summary
- refine workspace alias attempt generation to drop duplicate candidates and trim parent-directory prefixes when appropriate
- add coverage for downloading workspaces when only trimmed paths exist in the repository

## Testing
- pytest backend/tests/test_verify_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d9f50cf0b08331a225a61c7e20db93