### PR TITLE
Copy sources folder for script execution

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2768,6 +2768,13 @@ def verify_script(files: RepositoryFileAccessor, contract: dict) -> Tuple[bool, 
 
         repository = getattr(files, "repository", "")
         branch = getattr(files, "branch", "")
+        import shutil
+        # Copiar la carpeta 'sources' al directorio del script para soportar rutas relativas sencillas
+        sources_path = execution_root / "sources"
+        script_dir = local_script_path.parent
+        dest_sources = script_dir / "sources"
+        if sources_path.exists() and not dest_sources.exists():
+            shutil.copytree(sources_path, dest_sources, dirs_exist_ok=True)
 
         try:
             result = run_student_script(


### PR DESCRIPTION
## Summary
- ensure the sources folder is available alongside the executed script by copying it from the execution root when missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7317d4748331a92181a4055805a7